### PR TITLE
Typo in how to perform check for specific labels (#357)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,50 +8,52 @@ Warns and then closes issues and PRs that have had no activity for a specified a
 
 Every argument is optional.
 
-| Input                         | Description                                                                                                                                    |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `repo-token`                  | PAT(Personal Access Token) for authorizing repository.<br>_Defaults to **${{ github.token }}**_.                                               |
-| `days-before-stale`           | Idle number of days before marking an issue/PR as stale.<br>_Defaults to **60**_.                                                              |
-| `days-before-issue-stale`     | Idle number of days before marking an issue as stale.<br>_Override `days-before-stale`_.                                                       |
-| `days-before-pr-stale`        | Idle number of days before marking an PR as stale.<br>_Override `days-before-stale`_.                                                          |
-| `days-before-close`           | Idle number of days before closing an stale issue/PR.<br>_Defaults to **7**_.                                                                  |
-| `days-before-issue-close`     | Idle number of days before closing an stale issue.<br>_Override `days-before-close`_.                                                          |
-| `days-before-pr-close`        | Idle number of days before closing an stale PR.<br>_Override `days-before-close`_.                                                             |
-| `stale-issue-message`         | Message to post on the stale issue.                                                                                                            |
-| `stale-pr-message`            | Message to post on the stale PR.                                                                                                               |
-| `close-issue-message`         | Message to post on the stale issue while closing it.                                                                                           |
-| `close-pr-message`            | Message to post on the stale PR while closing it.                                                                                              |
-| `stale-issue-label`           | Label to apply on the stale issue.<br>_Defaults to **Stale**_.                                                                                 |
-| `close-issue-label`           | Label to apply on closing issue.<br>Automatically removed if no longer closed nor locked).                                                     |
-| `stale-pr-label`              | Label to apply on the stale PR.<br>_Defaults to **Stale**_.                                                                                    |
-| `close-pr-label`              | Label to apply on the closing PR.<br>Automatically removed if no longer closed nor locked).                                                    |
-| `exempt-issue-labels`         | Labels on an issue exempted from being marked as stale.                                                                                        |
-| `exempt-pr-labels`            | Labels on the PR exempted from being marked as stale.                                                                                          |
-| `only-labels`                 | Only issues and PRs with ALL these labels are checked.<br>Separate multiple labels with commas (eg. "question,answered").                      |
-| `only-issue-labels`           | Only issues with ALL these labels are checked.<br>Separate multiple labels with commas (eg. "question,answered").<br>_Override `only-labels`_. |
-| `only-pr-labels`              | Only PRs with ALL these labels are checked.<br>Separate multiple labels with commas (eg. "question,answered").<br>_Override `only-labels`_.    |
-| `any-of-labels`               | Only issues and PRs with ANY of these labels are checked.<br>Separate multiple labels with commas (eg. "incomplete,waiting-feedback").         |
-| `operations-per-run`          | Maximum number of operations per run.<br>GitHub API CRUD related.<br>_Defaults to **30**_.                                                     |
-| `remove-stale-when-updated`   | Remove stale label from issue/PR on updates or comments.<br>_Defaults to **true**_.                                                            |
-| `debug-only`                  | Dry-run on action.<br>_Defaults to **false**_.                                                                                                 |
-| `ascending`                   | Order to get issues/PR.<br>`true` is ascending, `false` is descending.<br>_Defaults to **false**_.                                             |
-| `skip-stale-issue-message`    | Skip adding stale message on stale issue.<br>_Defaults to **false**_.                                                                          |
-| `skip-stale-pr-message`       | Skip adding stale message on stale PR.<br>_Defaults to **false**_.                                                                             |
-| `start-date`                  | The date used to skip the stale action on issue/PR created before it.<br>ISO 8601 or RFC 2822.                                                 |
-| `delete-branch`               | Delete the git branch after closing a stale pull request.<br>_Defaults to **false**_.                                                          |
-| `exempt-milestones`           | Milestones on an issue or a PR exempted from being marked as stale.                                                                            |
-| `exempt-issue-milestones`     | Milestones on an issue exempted from being marked as stale.<br>_Override `exempt-milestones`_.                                                 |
-| `exempt-pr-milestones`        | Milestones on the PR exempted from being marked as stale.<br>_Override `exempt-milestones`_.                                                   |
-| `exempt-all-milestones`       | Exempt all issues and PRs with milestones from being marked as stale.<br>_Priority over `exempt-milestones` rules_.                            |
-| `exempt-all-issue-milestones` | Exempt all issues with milestones from being marked as stale.<br>_Override `exempt-all-milestones`_.                                           |
-| `exempt-all-pr-milestones`    | Exempt all PRs with milestones from being marked as stale.<br>_Override `exempt-all-milestones`_.                                              |
-| `exempt-assignees`            | Assignees on an issue or a PR exempted from being marked as stale.                                                                             |
-| `exempt-issue-assignees`      | Assignees on an issue exempted from being marked as stale.<br>_Override `exempt-assignees`_.                                                   |
-| `exempt-pr-assignees`         | Assignees on the PR exempted from being marked as stale.<br>_Override `exempt-assignees`_.                                                     |
-| `exempt-all-assignees`        | Exempt all issues and PRs with assignees from being marked as stale.<br>_Priority over `exempt-assignees` rules_.                              |
-| `exempt-all-issue-assignees`  | Exempt all issues with assignees from being marked as stale.<br>_Override `exempt-all-assignees`_.                                             |
-| `exempt-all-pr-assignees`     | Exempt all PRs with assignees from being marked as stale.<br>_Override `exempt-all-assignees`_.                                                |
-| `enable-statistics`           | Display some statistics at the end of the logs regarding the stale workflow.<br>Only when the logs are enabled.<br>_Defaults to **true**_.     |
+| Input                         | Description                                                                                                                                                   |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repo-token`                  | PAT(Personal Access Token) for authorizing repository.<br>_Defaults to **${{ github.token }}**_.                                                              |
+| `days-before-stale`           | Idle number of days before marking an issue/PR as stale.<br>_Defaults to **60**_.                                                                             |
+| `days-before-issue-stale`     | Idle number of days before marking an issue as stale.<br>_Override `days-before-stale`_.                                                                      |
+| `days-before-pr-stale`        | Idle number of days before marking an PR as stale.<br>_Override `days-before-stale`_.                                                                         |
+| `days-before-close`           | Idle number of days before closing an stale issue/PR.<br>_Defaults to **7**_.                                                                                 |
+| `days-before-issue-close`     | Idle number of days before closing an stale issue.<br>_Override `days-before-close`_.                                                                         |
+| `days-before-pr-close`        | Idle number of days before closing an stale PR.<br>_Override `days-before-close`_.                                                                            |
+| `stale-issue-message`         | Message to post on the stale issue.                                                                                                                           |
+| `stale-pr-message`            | Message to post on the stale PR.                                                                                                                              |
+| `close-issue-message`         | Message to post on the stale issue while closing it.                                                                                                          |
+| `close-pr-message`            | Message to post on the stale PR while closing it.                                                                                                             |
+| `stale-issue-label`           | Label to apply on the stale issue.<br>_Defaults to **Stale**_.                                                                                                |
+| `close-issue-label`           | Label to apply on closing issue.<br>Automatically removed if no longer closed nor locked).                                                                    |
+| `stale-pr-label`              | Label to apply on the stale PR.<br>_Defaults to **Stale**_.                                                                                                   |
+| `close-pr-label`              | Label to apply on the closing PR.<br>Automatically removed if no longer closed nor locked).                                                                   |
+| `exempt-issue-labels`         | Labels on an issue exempted from being marked as stale.                                                                                                       |
+| `exempt-pr-labels`            | Labels on the PR exempted from being marked as stale.                                                                                                         |
+| `only-labels`                 | Only issues and PRs with ALL these labels are checked.<br>Separate multiple labels with commas (eg. "question,answered").                                     |
+| `only-issue-labels`           | Only issues with ALL these labels are checked.<br>Separate multiple labels with commas (eg. "question,answered").<br>_Override `only-labels`_.                |
+| `only-pr-labels`              | Only PRs with ALL these labels are checked.<br>Separate multiple labels with commas (eg. "question,answered").<br>_Override `only-labels`_.                   |
+| `any-of-labels`               | Only issues and PRs with ANY of these labels are checked.<br>Separate multiple labels with commas (eg. "incomplete,waiting-feedback").                        |
+| `any-of-issue-labels`         | Only issues with ANY of these labels are checked.<br>Separate multiple labels with commas (eg. "incomplete,waiting-feedback").<br>_Override `any-of-labels`_. |
+| `any-of-pr-labels`            | Only PRs with ANY of these labels are checked.<br>Separate multiple labels with commas (eg. "incomplete,waiting-feedback").<br>_Override `any-of-labels`_.    |
+| `operations-per-run`          | Maximum number of operations per run.<br>GitHub API CRUD related.<br>_Defaults to **30**_.                                                                    |
+| `remove-stale-when-updated`   | Remove stale label from issue/PR on updates or comments.<br>_Defaults to **true**_.                                                                           |
+| `debug-only`                  | Dry-run on action.<br>_Defaults to **false**_.                                                                                                                |
+| `ascending`                   | Order to get issues/PR.<br>`true` is ascending, `false` is descending.<br>_Defaults to **false**_.                                                            |
+| `skip-stale-issue-message`    | Skip adding stale message on stale issue.<br>_Defaults to **false**_.                                                                                         |
+| `skip-stale-pr-message`       | Skip adding stale message on stale PR.<br>_Defaults to **false**_.                                                                                            |
+| `start-date`                  | The date used to skip the stale action on issue/PR created before it.<br>ISO 8601 or RFC 2822.                                                                |
+| `delete-branch`               | Delete the git branch after closing a stale pull request.<br>_Defaults to **false**_.                                                                         |
+| `exempt-milestones`           | Milestones on an issue or a PR exempted from being marked as stale.                                                                                           |
+| `exempt-issue-milestones`     | Milestones on an issue exempted from being marked as stale.<br>_Override `exempt-milestones`_.                                                                |
+| `exempt-pr-milestones`        | Milestones on the PR exempted from being marked as stale.<br>_Override `exempt-milestones`_.                                                                  |
+| `exempt-all-milestones`       | Exempt all issues and PRs with milestones from being marked as stale.<br>_Priority over `exempt-milestones` rules_.                                           |
+| `exempt-all-issue-milestones` | Exempt all issues with milestones from being marked as stale.<br>_Override `exempt-all-milestones`_.                                                          |
+| `exempt-all-pr-milestones`    | Exempt all PRs with milestones from being marked as stale.<br>_Override `exempt-all-milestones`_.                                                             |
+| `exempt-assignees`            | Assignees on an issue or a PR exempted from being marked as stale.                                                                                            |
+| `exempt-issue-assignees`      | Assignees on an issue exempted from being marked as stale.<br>_Override `exempt-assignees`_.                                                                  |
+| `exempt-pr-assignees`         | Assignees on the PR exempted from being marked as stale.<br>_Override `exempt-assignees`_.                                                                    |
+| `exempt-all-assignees`        | Exempt all issues and PRs with assignees from being marked as stale.<br>_Priority over `exempt-assignees` rules_.                                             |
+| `exempt-all-issue-assignees`  | Exempt all issues with assignees from being marked as stale.<br>_Override `exempt-all-assignees`_.                                                            |
+| `exempt-all-pr-assignees`     | Exempt all PRs with assignees from being marked as stale.<br>_Override `exempt-all-assignees`_.                                                               |
+| `enable-statistics`           | Display some statistics at the end of the logs regarding the stale workflow.<br>Only when the logs are enabled.<br>_Defaults to **true**_.                    |
 
 ### Detailed options
 
@@ -244,7 +246,7 @@ jobs:
       - uses: actions/stale@v3
         with:
           any-of-labels: 'needs-more-info,needs-demo'
-          # You can opt for 'only-labels' instead if your usecase requires all labels
+          # You can opt for 'only-labels' instead if your use-case requires all labels
           # to be present in the issue/PR
 ```
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ jobs:
           exempt-all-pr-milestones: true
 ```
 
-Avoid stale for specific labels:
+Check stale for specific labels:
 
 ```yaml
 name: 'Close stale issues and PRs'

--- a/__tests__/any-of-labels.spec.ts
+++ b/__tests__/any-of-labels.spec.ts
@@ -1,77 +1,1083 @@
 import {Issue} from '../src/classes/issue';
+import {IIssue} from '../src/interfaces/issue';
 import {IIssuesProcessorOptions} from '../src/interfaces/issues-processor-options';
 import {IssuesProcessorMock} from './classes/issues-processor-mock';
 import {DefaultProcessorOptions} from './constants/default-processor-options';
 import {generateIssue} from './functions/generate-issue';
 
-describe('any-of-labels option', () => {
-  test('should do nothing when not set', async () => {
-    const sut = new IssuesProcessorBuilder()
+let issuesProcessorBuilder: IssuesProcessorBuilder;
+let issuesProcessor: IssuesProcessorMock;
+
+describe('any-of-labels option', (): void => {
+  beforeEach((): void => {
+    issuesProcessorBuilder = new IssuesProcessorBuilder();
+  });
+
+  test('should stale when not set even if the issue has no label', async (): Promise<void> => {
+    expect.assertions(1);
+    issuesProcessor = issuesProcessorBuilder
       .emptyAnyOfLabels()
-      .issues([{labels: [{name: 'some-label'}]}])
+      .issuesOrPrs([{labels: []}])
       .build();
 
-    await sut.processIssues();
+    await issuesProcessor.processIssues();
 
-    expect(sut.staleIssues).toHaveLength(1);
+    expect(issuesProcessor.staleIssues).toHaveLength(1);
   });
 
-  test('should skip it when none of the issue labels match', async () => {
-    const sut = new IssuesProcessorBuilder()
-      .anyOfLabels('skip-this-issue,and-this-one')
-      .issues([{labels: [{name: 'some-label'}, {name: 'some-other-label'}]}])
+  test('should stale when not set even if the issue has a label', async (): Promise<void> => {
+    expect.assertions(1);
+    issuesProcessor = issuesProcessorBuilder
+      .emptyAnyOfLabels()
+      .issuesOrPrs([{labels: [{name: 'label'}]}])
       .build();
 
-    await sut.processIssues();
+    await issuesProcessor.processIssues();
 
-    expect(sut.staleIssues).toHaveLength(0);
+    expect(issuesProcessor.staleIssues).toHaveLength(1);
   });
 
-  test('should skip it when the issue has no labels', async () => {
-    const sut = new IssuesProcessorBuilder()
-      .anyOfLabels('skip-this-issue,and-this-one')
-      .issues([{labels: []}])
+  test('should not stale when set and the issue has no label', async (): Promise<void> => {
+    expect.assertions(1);
+    issuesProcessor = issuesProcessorBuilder
+      .anyOfLabels('dummy-label')
+      .issuesOrPrs([{labels: []}])
       .build();
 
-    await sut.processIssues();
+    await issuesProcessor.processIssues();
 
-    expect(sut.staleIssues).toHaveLength(0);
+    expect(issuesProcessor.staleIssues).toHaveLength(0);
   });
 
-  test('should process it when one of the issue labels match', async () => {
-    const sut = new IssuesProcessorBuilder()
-      .anyOfLabels('skip-this-issue,and-this-one')
-      .issues([{labels: [{name: 'some-label'}, {name: 'skip-this-issue'}]}])
+  test('should not stale when set and the issue has a different label', async (): Promise<void> => {
+    expect.assertions(1);
+    issuesProcessor = issuesProcessorBuilder
+      .anyOfLabels('dummy-label')
+      .issuesOrPrs([
+        {
+          labels: [
+            {
+              name: 'label'
+            }
+          ]
+        }
+      ])
       .build();
 
-    await sut.processIssues();
+    await issuesProcessor.processIssues();
 
-    expect(sut.staleIssues).toHaveLength(1);
+    expect(issuesProcessor.staleIssues).toHaveLength(0);
   });
 
-  test('should process it when all the issue labels match', async () => {
-    const sut = new IssuesProcessorBuilder()
-      .anyOfLabels('skip-this-issue,and-this-one')
-      .issues([{labels: [{name: 'and-this-one'}, {name: 'skip-this-issue'}]}])
+  test('should not stale when set and the issue has different labels', async (): Promise<void> => {
+    expect.assertions(1);
+    issuesProcessor = issuesProcessorBuilder
+      .anyOfLabels('dummy-label')
+      .issuesOrPrs([
+        {
+          labels: [
+            {
+              name: 'label-1'
+            },
+            {
+              name: 'label-2'
+            }
+          ]
+        }
+      ])
       .build();
 
-    await sut.processIssues();
+    await issuesProcessor.processIssues();
 
-    expect(sut.staleIssues).toHaveLength(1);
+    expect(issuesProcessor.staleIssues).toHaveLength(0);
+  });
+
+  test('should stale when set and the issue has the same label', async (): Promise<void> => {
+    expect.assertions(1);
+    issuesProcessor = issuesProcessorBuilder
+      .anyOfLabels('dummy-label')
+      .issuesOrPrs([
+        {
+          labels: [
+            {
+              name: 'dummy-label'
+            }
+          ]
+        }
+      ])
+      .build();
+
+    await issuesProcessor.processIssues();
+
+    expect(issuesProcessor.staleIssues).toHaveLength(1);
+  });
+
+  test('should stale when set and the issue has only one of the same label', async (): Promise<void> => {
+    expect.assertions(1);
+    issuesProcessor = issuesProcessorBuilder
+      .anyOfLabels('dummy-label-1,dummy-label-2')
+      .issuesOrPrs([
+        {
+          labels: [
+            {
+              name: 'dummy-label-1'
+            }
+          ]
+        }
+      ])
+      .build();
+
+    await issuesProcessor.processIssues();
+
+    expect(issuesProcessor.staleIssues).toHaveLength(1);
+  });
+
+  test('should stale when set and the issue has all the same labels', async (): Promise<void> => {
+    expect.assertions(1);
+    issuesProcessor = issuesProcessorBuilder
+      .anyOfLabels('dummy-label-1,dummy-label-2')
+      .issuesOrPrs([
+        {
+          labels: [
+            {
+              name: 'dummy-label-1'
+            },
+            {
+              name: 'dummy-label-2'
+            }
+          ]
+        }
+      ])
+      .build();
+
+    await issuesProcessor.processIssues();
+
+    expect(issuesProcessor.staleIssues).toHaveLength(1);
+  });
+});
+
+describe('any-of-issue-labels option', (): void => {
+  beforeEach((): void => {
+    issuesProcessorBuilder = new IssuesProcessorBuilder();
+  });
+
+  describe('when the any-of-labels options is not set', (): void => {
+    beforeEach((): void => {
+      issuesProcessorBuilder.emptyAnyOfLabels();
+    });
+
+    test('should stale when not set even if the issue has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfIssueLabels()
+        .issues([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when not set even if the issue has a label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfIssueLabels()
+        .issues([{labels: [{name: 'dummy-label'}]}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should not stale when set and the issue has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the issue has a different label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the issue has different labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'label-1'
+              },
+              {
+                name: 'label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should stale when set and the issue has the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'dummy-label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the issue has only one of the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label-1,dummy-label-2')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the issue has all the same labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label-1,dummy-label-2')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              },
+              {
+                name: 'dummy-label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+  });
+
+  describe('when the any-of-labels options is set (same as any-of-issue-labels)', (): void => {
+    beforeEach((): void => {
+      issuesProcessorBuilder.anyOfLabels('dummy-label');
+    });
+
+    test('should not stale when not set even if the issue has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfIssueLabels()
+        .issues([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when not set even if the issue has a label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfIssueLabels()
+        .issues([{labels: [{name: 'label'}]}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the issue has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the issue has a different label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the issue has different labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'label-1'
+              },
+              {
+                name: 'label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should stale when set and the issue has the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'dummy-label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the issue has only one of the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label-1,dummy-label-2')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the issue has all the same labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label-1,dummy-label-2')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              },
+              {
+                name: 'dummy-label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+  });
+
+  describe('when the any-of-labels options is set (different than any-of-issue-labels)', (): void => {
+    beforeEach((): void => {
+      issuesProcessorBuilder.anyOfLabels('dummy-any-of-label');
+    });
+
+    test('should not stale when not set even if the issue has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfIssueLabels()
+        .issues([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when not set even if the issue has a label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfIssueLabels()
+        .issues([{labels: [{name: 'label'}]}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the issue has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the issue has a different label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the issue has different labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'label-1'
+              },
+              {
+                name: 'label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should stale when set and the issue has the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'dummy-label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the issue has only one of the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label-1,dummy-label-2')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the issue has all the same labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfIssueLabels('dummy-label-1,dummy-label-2')
+        .issues([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              },
+              {
+                name: 'dummy-label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+  });
+});
+
+describe('any-of-pr-labels option', (): void => {
+  beforeEach((): void => {
+    issuesProcessorBuilder = new IssuesProcessorBuilder();
+  });
+
+  describe('when the any-of-labels options is not set', (): void => {
+    beforeEach((): void => {
+      issuesProcessorBuilder.emptyAnyOfLabels();
+    });
+
+    test('should stale when not set even if the pr has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfPrLabels()
+        .prs([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when not set even if the pr has a label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfPrLabels()
+        .prs([{labels: [{name: 'dummy-label'}]}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should not stale when set and the pr has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the pr has a different label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the pr has different labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'label-1'
+              },
+              {
+                name: 'label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should stale when set and the pr has the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'dummy-label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the pr has only one of the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label-1,dummy-label-2')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the pr has all the same labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label-1,dummy-label-2')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              },
+              {
+                name: 'dummy-label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+  });
+
+  describe('when the any-of-labels options is set (same as any-of-pr-labels)', (): void => {
+    beforeEach((): void => {
+      issuesProcessorBuilder.anyOfLabels('dummy-label');
+    });
+
+    test('should not stale when not set even if the pr has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfPrLabels()
+        .prs([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when not set even if the pr has a label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfPrLabels()
+        .prs([{labels: [{name: 'label'}]}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the pr has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the pr has a different label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the pr has different labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'label-1'
+              },
+              {
+                name: 'label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should stale when set and the pr has the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'dummy-label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the pr has only one of the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label-1,dummy-label-2')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the pr has all the same labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label-1,dummy-label-2')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              },
+              {
+                name: 'dummy-label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+  });
+
+  describe('when the any-of-labels options is set (different than any-of-pr-labels)', (): void => {
+    beforeEach((): void => {
+      issuesProcessorBuilder.anyOfLabels('dummy-any-of-label');
+    });
+
+    test('should not stale when not set even if the pr has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfPrLabels()
+        .prs([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when not set even if the pr has a label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .emptyAnyOfPrLabels()
+        .prs([{labels: [{name: 'label'}]}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the pr has no label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([{labels: []}])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the pr has a different label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should not stale when set and the pr has different labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'label-1'
+              },
+              {
+                name: 'label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(0);
+    });
+
+    test('should stale when set and the pr has the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'dummy-label'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the pr has only one of the same label', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label-1,dummy-label-2')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
+
+    test('should stale when set and the pr has all the same labels', async (): Promise<void> => {
+      expect.assertions(1);
+      issuesProcessor = issuesProcessorBuilder
+        .anyOfPrLabels('dummy-label-1,dummy-label-2')
+        .prs([
+          {
+            labels: [
+              {
+                name: 'dummy-label-1'
+              },
+              {
+                name: 'dummy-label-2'
+              }
+            ]
+          }
+        ])
+        .build();
+
+      await issuesProcessor.processIssues();
+
+      expect(issuesProcessor.staleIssues).toHaveLength(1);
+    });
   });
 });
 
 class IssuesProcessorBuilder {
-  private _options: IIssuesProcessorOptions;
-  private _issues: Issue[];
-
-  constructor() {
-    this._options = {...DefaultProcessorOptions};
-    this._issues = [];
-  }
+  private _options: IIssuesProcessorOptions = {
+    ...DefaultProcessorOptions,
+    daysBeforeStale: 0
+  };
+  private _issues: Issue[] = [];
 
   anyOfLabels(labels: string): IssuesProcessorBuilder {
     this._options.anyOfLabels = labels;
+
+    return this;
+  }
+
+  anyOfIssueLabels(labels: string): IssuesProcessorBuilder {
+    this._options.anyOfIssueLabels = labels;
+
+    return this;
+  }
+
+  anyOfPrLabels(labels: string): IssuesProcessorBuilder {
+    this._options.anyOfPrLabels = labels;
+
     return this;
   }
 
@@ -79,19 +1085,58 @@ class IssuesProcessorBuilder {
     return this.anyOfLabels('');
   }
 
-  issues(issues: Partial<Issue>[]): IssuesProcessorBuilder {
+  emptyAnyOfIssueLabels(): IssuesProcessorBuilder {
+    return this.anyOfIssueLabels('');
+  }
+
+  emptyAnyOfPrLabels(): IssuesProcessorBuilder {
+    return this.anyOfPrLabels('');
+  }
+
+  issuesOrPrs(issues: Partial<IIssue>[]): IssuesProcessorBuilder {
     this._issues = issues.map(
-      (issue, index): Issue =>
+      (issue: Readonly<Partial<IIssue>>, index: Readonly<number>): Issue =>
         generateIssue(
           this._options,
           index,
-          issue.title || 'Issue title',
-          issue.updated_at || '2000-01-01T00:00:00Z', // we only care about stale/expired issues here
-          issue.created_at || '2000-01-01T00:00:00Z',
-          issue.isPullRequest || false,
+          issue.title ?? 'dummy-title',
+          issue.updated_at ?? new Date().toDateString(),
+          issue.created_at ?? new Date().toDateString(),
+          !!issue.pull_request,
           issue.labels ? issue.labels.map(label => label.name) : []
         )
     );
+
+    return this;
+  }
+
+  issues(issues: Partial<IIssue>[]): IssuesProcessorBuilder {
+    this.issuesOrPrs(
+      issues.map(
+        (issue: Readonly<Partial<IIssue>>): Partial<IIssue> => {
+          return {
+            ...issue,
+            pull_request: null
+          };
+        }
+      )
+    );
+
+    return this;
+  }
+
+  prs(issues: Partial<IIssue>[]): IssuesProcessorBuilder {
+    this.issuesOrPrs(
+      issues.map(
+        (issue: Readonly<Partial<IIssue>>): Partial<IIssue> => {
+          return {
+            ...issue,
+            pull_request: {key: 'value'}
+          };
+        }
+      )
+    );
+
     return this;
   }
 

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -22,6 +22,8 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   onlyIssueLabels: '',
   onlyPrLabels: '',
   anyOfLabels: '',
+  anyOfIssueLabels: '',
+  anyOfPrLabels: '',
   operationsPerRun: 100,
   debugOnly: true,
   removeStaleWhenUpdated: false,

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,14 @@ inputs:
     description: 'Only issues or pull requests with at least one of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels.'
     default: ''
     required: false
+  any-of-issue-labels:
+    description: 'Only issues with at least one of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels. Override "any-of-labels" option regarding only the issues.'
+    default: ''
+    required: false
+  any-of-pr-labels:
+    description: 'Only pull requests with at least one of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels. Override "any-of-labels" option regarding only the pull requests.'
+    default: ''
+    required: false
   only-issue-labels:
     description: 'Only issues with all of these labels are checked if stale. Defaults to `[]` (disabled) and can be a comma-separated list of labels. Override "only-labels" option regarding only the issues.'
     default: ''

--- a/dist/index.js
+++ b/dist/index.js
@@ -312,15 +312,17 @@ class IssuesProcessor {
                         return is_labeled_1.isLabeled(issue, label);
                     });
                     if (!hasAllWhitelistedLabels) {
-                        issueLogger.info(`Skipping this $$type because it doesn't have all the required labels`);
+                        issueLogger.info(chalk_1.default.white('└──'), `Skipping this $$type because it doesn't have all the required labels`);
                         continue; // Don't process issues without all of the required labels
                     }
                     else {
-                        issueLogger.info(`All the required labels are present on this $$type. Continuing the process`);
+                        issueLogger.info(chalk_1.default.white('├──'), `All the required labels are present on this $$type`);
+                        issueLogger.info(chalk_1.default.white('└──'), `Continuing the process for this $$type`);
                     }
                 }
                 else {
-                    issueLogger.info(`The option "onlyLabels" was not specified. Continuing the process for this $$type`);
+                    issueLogger.info(`The option "onlyLabels" was not specified`);
+                    issueLogger.info(chalk_1.default.white('└──'), `Continuing the process for this $$type`);
                 }
                 issueLogger.info(`Days before $$type stale: ${daysBeforeStale}`);
                 const shouldMarkAsStale = should_mark_when_stale_1.shouldMarkWhenStale(daysBeforeStale);
@@ -370,11 +372,24 @@ class IssuesProcessor {
                     issueLogger.info(`Skipping $$type because it has an exempt label`);
                     continue; // don't process exempt issues
                 }
-                const anyOfLabels = words_to_list_1.wordsToList(this.options.anyOfLabels);
-                if (anyOfLabels.length &&
-                    !anyOfLabels.some((label) => is_labeled_1.isLabeled(issue, label))) {
-                    issueLogger.info(`Skipping $$type because it does not have any of the required labels`);
-                    continue; // don't process issues without any of the required labels
+                const anyOfLabels = words_to_list_1.wordsToList(this._getAnyOfLabels(issue));
+                if (anyOfLabels.length > 0) {
+                    issueLogger.info(`The option "anyOfLabels" was specified to only processed the issues and pull requests with one of those labels (${anyOfLabels.length})`);
+                    const hasOneOfWhitelistedLabels = anyOfLabels.some((label) => {
+                        return is_labeled_1.isLabeled(issue, label);
+                    });
+                    if (!hasOneOfWhitelistedLabels) {
+                        issueLogger.info(chalk_1.default.white('└──'), `Skipping this $$type because it doesn't have one of the required labels`);
+                        continue; // Don't process issues without any of the required labels
+                    }
+                    else {
+                        issueLogger.info(chalk_1.default.white('├──'), `One of the required labels is present on this $$type`);
+                        issueLogger.info(chalk_1.default.white('└──'), `Continuing the process for this $$type`);
+                    }
+                }
+                else {
+                    issueLogger.info(`The option "anyOfLabels" was not specified`);
+                    issueLogger.info(chalk_1.default.white('└──'), `Continuing the process for this $$type`);
                 }
                 const milestones = new milestones_1.Milestones(this.options, issue);
                 if (milestones.shouldExemptMilestones()) {
@@ -758,6 +773,19 @@ class IssuesProcessor {
             }
         }
         return this.options.onlyLabels;
+    }
+    _getAnyOfLabels(issue) {
+        if (issue.isPullRequest) {
+            if (this.options.anyOfPrLabels !== '') {
+                return this.options.anyOfPrLabels;
+            }
+        }
+        else {
+            if (this.options.anyOfIssueLabels !== '') {
+                return this.options.anyOfIssueLabels;
+            }
+        }
+        return this.options.anyOfLabels;
     }
     _removeStaleLabel(issue, staleLabel) {
         var _a;
@@ -1758,6 +1786,8 @@ function _getAndValidateArgs() {
         onlyIssueLabels: core.getInput('only-issue-labels'),
         onlyPrLabels: core.getInput('only-pr-labels'),
         anyOfLabels: core.getInput('any-of-labels'),
+        anyOfIssueLabels: core.getInput('any-of-issue-labels'),
+        anyOfPrLabels: core.getInput('any-of-pr-labels'),
         operationsPerRun: parseInt(core.getInput('operations-per-run', { required: true })),
         removeStaleWhenUpdated: !(core.getInput('remove-stale-when-updated') === 'false'),
         debugOnly: core.getInput('debug-only') === 'true',

--- a/dist/index.js
+++ b/dist/index.js
@@ -12,7 +12,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Assignees = void 0;
+const chalk_1 = __importDefault(__nccwpck_require__(8818));
 const lodash_deburr_1 = __importDefault(__nccwpck_require__(1601));
+const option_1 = __nccwpck_require__(5931);
 const words_to_list_1 = __nccwpck_require__(1883);
 const issue_logger_1 = __nccwpck_require__(2984);
 class Assignees {
@@ -31,23 +33,23 @@ class Assignees {
             return false;
         }
         if (this._shouldExemptAllAssignees()) {
-            this._issueLogger.info('Skipping $$type because it has an exempt assignee');
+            this._issueLogger.info(chalk_1.default.white('└──'), 'Skipping $$type because it has an exempt assignee');
             return true;
         }
         const exemptAssignees = this._getExemptAssignees();
         if (exemptAssignees.length === 0) {
-            this._issueLogger.info(`No assignee option was specified to skip the stale process for this $$type`);
+            this._issueLogger.info(chalk_1.default.white('├──'), `No assignee option was specified to skip the stale process for this $$type`);
             this._logSkip();
             return false;
         }
-        this._issueLogger.info(`Found ${exemptAssignees.length} assignee${exemptAssignees.length > 1 ? 's' : ''} that can exempt stale on this $$type`);
+        this._issueLogger.info(chalk_1.default.white('├──'), `Found ${chalk_1.default.cyan(exemptAssignees.length)} assignee${exemptAssignees.length > 1 ? 's' : ''} that can exempt stale on this $$type`);
         const hasExemptAssignee = exemptAssignees.some((exemptAssignee) => this._hasAssignee(exemptAssignee));
         if (!hasExemptAssignee) {
-            this._issueLogger.info('No assignee on this $$type can exempt the stale process');
+            this._issueLogger.info(chalk_1.default.white('├──'), 'No assignee on this $$type can exempt the stale process');
             this._logSkip();
         }
         else {
-            this._issueLogger.info('Skipping this $$type because it has an exempt assignee');
+            this._issueLogger.info(chalk_1.default.white('└──'), 'Skipping this $$type because it has an exempt assignee');
         }
         return hasExemptAssignee;
     }
@@ -58,32 +60,32 @@ class Assignees {
     }
     _getExemptIssueAssignees() {
         if (this._options.exemptIssueAssignees === '') {
-            this._issueLogger.info('The option "exemptIssueAssignees" is disabled. No specific assignee can skip the stale process for this $$type');
+            this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptIssueAssignees)} is disabled. No specific assignee can skip the stale process for this $$type`);
             if (this._options.exemptAssignees === '') {
-                this._issueLogger.info('The option "exemptAssignees" is disabled. No specific assignee can skip the stale process for this $$type');
+                this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAssignees)} is disabled. No specific assignee can skip the stale process for this $$type`);
                 return [];
             }
             const exemptAssignees = words_to_list_1.wordsToList(this._options.exemptAssignees);
-            this._issueLogger.info(`The option "exemptAssignees" is set. ${exemptAssignees.length} assignee${exemptAssignees.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
+            this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAssignees)} is set. ${chalk_1.default.cyan(exemptAssignees.length)} assignee${exemptAssignees.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
             return exemptAssignees;
         }
         const exemptAssignees = words_to_list_1.wordsToList(this._options.exemptIssueAssignees);
-        this._issueLogger.info(`The option "exemptIssueAssignees" is set. ${exemptAssignees.length} assignee${exemptAssignees.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
+        this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptIssueAssignees)} is set. ${chalk_1.default.cyan(exemptAssignees.length)} assignee${exemptAssignees.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
         return exemptAssignees;
     }
     _getExemptPullRequestAssignees() {
         if (this._options.exemptPrAssignees === '') {
-            this._issueLogger.info('The option "exemptPrAssignees" is disabled. No specific assignee can skip the stale process for this $$type');
+            this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptPrAssignees)} is disabled. No specific assignee can skip the stale process for this $$type`);
             if (this._options.exemptAssignees === '') {
-                this._issueLogger.info('The option "exemptAssignees" is disabled. No specific assignee can skip the stale process for this $$type');
+                this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAssignees)} is disabled. No specific assignee can skip the stale process for this $$type`);
                 return [];
             }
             const exemptAssignees = words_to_list_1.wordsToList(this._options.exemptAssignees);
-            this._issueLogger.info(`The option "exemptAssignees" is set. ${exemptAssignees.length} assignee${exemptAssignees.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
+            this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAssignees)} is set. ${chalk_1.default.cyan(exemptAssignees.length)} assignee${exemptAssignees.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
             return exemptAssignees;
         }
         const exemptAssignees = words_to_list_1.wordsToList(this._options.exemptPrAssignees);
-        this._issueLogger.info(`The option "exemptPrAssignees" is set. ${exemptAssignees.length} assignee${exemptAssignees.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
+        this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptPrAssignees)} is set. ${chalk_1.default.cyan(exemptAssignees.length)} assignee${exemptAssignees.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
         return exemptAssignees;
     }
     _hasAssignee(assignee) {
@@ -91,7 +93,7 @@ class Assignees {
         return this._issue.assignees.some((issueAssignee) => {
             const isSameAssignee = cleanAssignee === Assignees._cleanAssignee(issueAssignee.login);
             if (isSameAssignee) {
-                this._issueLogger.info(`@${issueAssignee.login} is assigned on this $$type and is an exempt assignee`);
+                this._issueLogger.info(chalk_1.default.white('├──'), `@${issueAssignee.login} is assigned on this $$type and is an exempt assignee`);
             }
             return isSameAssignee;
         });
@@ -103,11 +105,11 @@ class Assignees {
     }
     _shouldExemptAllIssueAssignees() {
         if (this._options.exemptAllIssueAssignees === true) {
-            this._issueLogger.info('The option "exemptAllIssueAssignees" is enabled. Any assignee on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllIssueAssignees)} is enabled. Any assignee on this $$type will skip the stale process`);
             return true;
         }
         else if (this._options.exemptAllIssueAssignees === false) {
-            this._issueLogger.info('The option "exemptAllIssueAssignees" is disabled. Only some specific assignees on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllIssueAssignees)} is disabled. Only some specific assignees on this $$type will skip the stale process`);
             return false;
         }
         this._logExemptAllAssigneesOption();
@@ -115,11 +117,11 @@ class Assignees {
     }
     _shouldExemptAllPullRequestAssignees() {
         if (this._options.exemptAllPrAssignees === true) {
-            this._issueLogger.info('The option "exemptAllPrAssignees" is enabled. Any assignee on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllPrAssignees)} is enabled. Any assignee on this $$type will skip the stale process`);
             return true;
         }
         else if (this._options.exemptAllPrAssignees === false) {
-            this._issueLogger.info('The option "exemptAllPrAssignees" is disabled. Only some specific assignees on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllPrAssignees)} is disabled. Only some specific assignees on this $$type will skip the stale process`);
             return false;
         }
         this._logExemptAllAssigneesOption();
@@ -127,14 +129,14 @@ class Assignees {
     }
     _logExemptAllAssigneesOption() {
         if (this._options.exemptAllAssignees) {
-            this._issueLogger.info('The option "exemptAllAssignees" is enabled. Any assignee on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllAssignees)} is enabled. Any assignee on this $$type will skip the stale process`);
         }
         else {
-            this._issueLogger.info('The option "exemptAllAssignees" is disabled. Only some specific assignees on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllAssignees)} is disabled. Only some specific assignees on this $$type will skip the stale process`);
         }
     }
     _logSkip() {
-        this._issueLogger.info('Skip the assignees checks');
+        this._issueLogger.info(chalk_1.default.white('└──'), 'Skip the assignees checks');
     }
 }
 exports.Assignees = Assignees;
@@ -955,7 +957,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Milestones = void 0;
+const chalk_1 = __importDefault(__nccwpck_require__(8818));
 const lodash_deburr_1 = __importDefault(__nccwpck_require__(1601));
+const option_1 = __nccwpck_require__(5931);
 const words_to_list_1 = __nccwpck_require__(1883);
 const issue_logger_1 = __nccwpck_require__(2984);
 class Milestones {
@@ -974,23 +978,23 @@ class Milestones {
             return false;
         }
         if (this._shouldExemptAllMilestones()) {
-            this._issueLogger.info('Skipping $$type because it has an exempt milestone');
+            this._issueLogger.info(chalk_1.default.white('└──'), 'Skipping $$type because it has a milestone');
             return true;
         }
         const exemptMilestones = this._getExemptMilestones();
         if (exemptMilestones.length === 0) {
-            this._issueLogger.info(`No milestone option was specified to skip the stale process for this $$type`);
+            this._issueLogger.info(chalk_1.default.white('├──'), `No milestone option was specified to skip the stale process for this $$type`);
             this._logSkip();
             return false;
         }
-        this._issueLogger.info(`Found ${exemptMilestones.length} milestone${exemptMilestones.length > 1 ? 's' : ''} that can exempt stale on this $$type`);
+        this._issueLogger.info(chalk_1.default.white('├──'), `Found ${chalk_1.default.cyan(exemptMilestones.length)} milestone${exemptMilestones.length > 1 ? 's' : ''} that can exempt stale on this $$type`);
         const hasExemptMilestone = exemptMilestones.some((exemptMilestone) => this._hasMilestone(exemptMilestone));
         if (!hasExemptMilestone) {
-            this._issueLogger.info('No milestone on this $$type can exempt the stale process');
+            this._issueLogger.info(chalk_1.default.white('├──'), 'No milestone on this $$type can exempt the stale process');
             this._logSkip();
         }
         else {
-            this._issueLogger.info('Skipping this $$type because it has an exempt milestone');
+            this._issueLogger.info(chalk_1.default.white('└──'), 'Skipping this $$type because it has an exempt milestone');
         }
         return hasExemptMilestone;
     }
@@ -1001,32 +1005,32 @@ class Milestones {
     }
     _getExemptIssueMilestones() {
         if (this._options.exemptIssueMilestones === '') {
-            this._issueLogger.info('The option "exemptIssueMilestones" is disabled. No specific milestone can skip the stale process for this $$type');
+            this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptIssueMilestones)} is disabled. No specific milestone can skip the stale process for this $$type`);
             if (this._options.exemptMilestones === '') {
-                this._issueLogger.info('The option "exemptMilestones" is disabled. No specific milestone can skip the stale process for this $$type');
+                this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptMilestones)} is disabled. No specific milestone can skip the stale process for this $$type`);
                 return [];
             }
             const exemptMilestones = words_to_list_1.wordsToList(this._options.exemptMilestones);
-            this._issueLogger.info(`The option "exemptMilestones" is set. ${exemptMilestones.length} milestone${exemptMilestones.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
+            this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptMilestones)} is set. ${chalk_1.default.cyan(exemptMilestones.length)} milestone${exemptMilestones.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
             return exemptMilestones;
         }
         const exemptMilestones = words_to_list_1.wordsToList(this._options.exemptIssueMilestones);
-        this._issueLogger.info(`The option "exemptIssueMilestones" is set. ${exemptMilestones.length} milestone${exemptMilestones.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
+        this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptIssueMilestones)} is set. ${chalk_1.default.cyan(exemptMilestones.length)} milestone${exemptMilestones.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
         return exemptMilestones;
     }
     _getExemptPullRequestMilestones() {
         if (this._options.exemptPrMilestones === '') {
-            this._issueLogger.info('The option "exemptPrMilestones" is disabled. No specific milestone can skip the stale process for this $$type');
+            this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptPrMilestones)} is disabled. No specific milestone can skip the stale process for this $$type`);
             if (this._options.exemptMilestones === '') {
-                this._issueLogger.info('The option "exemptMilestones" is disabled. No specific milestone can skip the stale process for this $$type');
+                this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptMilestones)} is disabled. No specific milestone can skip the stale process for this $$type`);
                 return [];
             }
             const exemptMilestones = words_to_list_1.wordsToList(this._options.exemptMilestones);
-            this._issueLogger.info(`The option "exemptMilestones" is set. ${exemptMilestones.length} milestone${exemptMilestones.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
+            this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptMilestones)} is set. ${chalk_1.default.cyan(exemptMilestones.length)} milestone${exemptMilestones.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
             return exemptMilestones;
         }
         const exemptMilestones = words_to_list_1.wordsToList(this._options.exemptPrMilestones);
-        this._issueLogger.info(`The option "exemptPrMilestones" is set. ${exemptMilestones.length} milestone${exemptMilestones.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
+        this._issueLogger.info(chalk_1.default.white('├──'), `The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptPrMilestones)} is set. ${chalk_1.default.cyan(exemptMilestones.length)} milestone${exemptMilestones.length === 1 ? '' : 's'} can skip the stale process for this $$type`);
         return exemptMilestones;
     }
     _hasMilestone(milestone) {
@@ -1037,7 +1041,7 @@ class Milestones {
         const isSameMilestone = cleanMilestone ===
             Milestones._cleanMilestone(this._issue.milestone.title);
         if (isSameMilestone) {
-            this._issueLogger.info(`The milestone "${milestone}" is set on this $$type and is an exempt milestone`);
+            this._issueLogger.info(chalk_1.default.white('├──'), `The milestone "${milestone}" is set on this $$type and is an exempt milestone`);
         }
         return isSameMilestone;
     }
@@ -1051,11 +1055,11 @@ class Milestones {
     }
     _shouldExemptAllIssueMilestones() {
         if (this._options.exemptAllIssueMilestones === true) {
-            this._issueLogger.info('The option "exemptAllIssueMilestones" is enabled. Any milestone on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllIssueMilestones)} is enabled. Any milestone on this $$type will skip the stale process`);
             return true;
         }
         else if (this._options.exemptAllIssueMilestones === false) {
-            this._issueLogger.info('The option "exemptAllIssueMilestones" is disabled. Only some specific milestones on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllIssueMilestones)} is disabled. Only some specific milestones on this $$type will skip the stale process`);
             return false;
         }
         this._logExemptAllMilestonesOption();
@@ -1063,11 +1067,11 @@ class Milestones {
     }
     _shouldExemptAllPullRequestMilestones() {
         if (this._options.exemptAllPrMilestones === true) {
-            this._issueLogger.info('The option "exemptAllPrMilestones" is enabled. Any milestone on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllPrMilestones)} is enabled. Any milestone on this $$type will skip the stale process`);
             return true;
         }
         else if (this._options.exemptAllPrMilestones === false) {
-            this._issueLogger.info('The option "exemptAllPrMilestones" is disabled. Only some specific milestones on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllPrMilestones)} is disabled. Only some specific milestones on this $$type will skip the stale process`);
             return false;
         }
         this._logExemptAllMilestonesOption();
@@ -1075,14 +1079,14 @@ class Milestones {
     }
     _logExemptAllMilestonesOption() {
         if (this._options.exemptAllMilestones) {
-            this._issueLogger.info('The option "exemptAllMilestones" is enabled. Any milestone on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllMilestones)} is enabled. Any milestone on this $$type will skip the stale process`);
         }
         else {
-            this._issueLogger.info('The option "exemptAllMilestones" is disabled. Only some specific milestones on this $$type will skip the stale process');
+            this._issueLogger.info(`The option ${this._issueLogger.createOptionLink(option_1.Option.ExemptAllMilestones)} is disabled. Only some specific milestones on this $$type will skip the stale process`);
         }
     }
     _logSkip() {
-        this._issueLogger.info('Skip the milestones checks');
+        this._issueLogger.info(chalk_1.default.white('└──'), 'Skip the milestones checks');
     }
 }
 exports.Milestones = Milestones;

--- a/src/classes/assignees.spec.ts
+++ b/src/classes/assignees.spec.ts
@@ -2,8 +2,8 @@ import {DefaultProcessorOptions} from '../../__tests__/constants/default-process
 import {generateIIssue} from '../../__tests__/functions/generate-iissue';
 import {IIssue} from '../interfaces/issue';
 import {IIssuesProcessorOptions} from '../interfaces/issues-processor-options';
-import {Issue} from './issue';
 import {Assignees} from './assignees';
+import {Issue} from './issue';
 
 describe('Assignees', (): void => {
   let assignees: Assignees;
@@ -12,7 +12,10 @@ describe('Assignees', (): void => {
   let issueInterface: IIssue;
 
   beforeEach((): void => {
-    optionsInterface = {...DefaultProcessorOptions};
+    optionsInterface = {
+      ...DefaultProcessorOptions,
+      exemptAllAssignees: false
+    };
     issueInterface = generateIIssue();
   });
 
@@ -303,21 +306,51 @@ describe('Assignees', (): void => {
           });
         });
       });
-    });
 
-    describe('when the given issue is a pull request', (): void => {
-      beforeEach((): void => {
-        issueInterface.pull_request = {};
-      });
-
-      describe('when the given options are not configured to exempt an assignee', (): void => {
+      describe('when the given options are configured to exempt all assignees', (): void => {
         beforeEach((): void => {
-          optionsInterface.exemptAssignees = '';
+          optionsInterface.exemptAllAssignees = true;
         });
 
-        describe('when the given options are not configured to exempt a pull request with an assignee', (): void => {
+        describe('when the given issue does not have an assignee', (): void => {
           beforeEach((): void => {
-            optionsInterface.exemptPrAssignees = '';
+            issueInterface.assignees = [];
+          });
+
+          it('should return false', (): void => {
+            expect.assertions(1);
+            issue = new Issue(optionsInterface, issueInterface);
+            assignees = new Assignees(optionsInterface, issue);
+
+            const result = assignees.shouldExemptAssignees();
+
+            expect(result).toStrictEqual(false);
+          });
+        });
+
+        describe('when the given issue does have an assignee', (): void => {
+          beforeEach((): void => {
+            issueInterface.assignees = [
+              {
+                login: 'dummy-exempt-assignee'
+              }
+            ];
+          });
+
+          it('should return true', (): void => {
+            expect.assertions(1);
+            issue = new Issue(optionsInterface, issueInterface);
+            assignees = new Assignees(optionsInterface, issue);
+
+            const result = assignees.shouldExemptAssignees();
+
+            expect(result).toStrictEqual(true);
+          });
+        });
+
+        describe('when the given options are not configured to exempt all issue assignees', (): void => {
+          beforeEach((): void => {
+            optionsInterface.exemptAllIssueAssignees = false;
           });
 
           describe('when the given issue does not have an assignee', (): void => {
@@ -337,6 +370,102 @@ describe('Assignees', (): void => {
           });
 
           describe('when the given issue does have an assignee', (): void => {
+            beforeEach((): void => {
+              issueInterface.assignees = [
+                {
+                  login: 'dummy-exempt-assignee'
+                }
+              ];
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              assignees = new Assignees(optionsInterface, issue);
+
+              const result = assignees.shouldExemptAssignees();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+        });
+
+        describe('when the given options are configured to exempt all issue assignees', (): void => {
+          beforeEach((): void => {
+            optionsInterface.exemptAllIssueAssignees = true;
+          });
+
+          describe('when the given issue does not have an assignee', (): void => {
+            beforeEach((): void => {
+              issueInterface.assignees = [];
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              assignees = new Assignees(optionsInterface, issue);
+
+              const result = assignees.shouldExemptAssignees();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+
+          describe('when the given issue does have an assignee', (): void => {
+            beforeEach((): void => {
+              issueInterface.assignees = [
+                {
+                  login: 'dummy-exempt-issue-assignee'
+                }
+              ];
+            });
+
+            it('should return true', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              assignees = new Assignees(optionsInterface, issue);
+
+              const result = assignees.shouldExemptAssignees();
+
+              expect(result).toStrictEqual(true);
+            });
+          });
+        });
+      });
+    });
+
+    describe('when the given issue is a pull request', (): void => {
+      beforeEach((): void => {
+        issueInterface.pull_request = {};
+      });
+
+      describe('when the given options are not configured to exempt an assignee', (): void => {
+        beforeEach((): void => {
+          optionsInterface.exemptAssignees = '';
+        });
+
+        describe('when the given options are not configured to exempt a pull request with an assignee', (): void => {
+          beforeEach((): void => {
+            optionsInterface.exemptPrAssignees = '';
+          });
+
+          describe('when the given pull request does not have an assignee', (): void => {
+            beforeEach((): void => {
+              issueInterface.assignees = [];
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              assignees = new Assignees(optionsInterface, issue);
+
+              const result = assignees.shouldExemptAssignees();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+
+          describe('when the given pull request does have an assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [
                 {
@@ -362,7 +491,7 @@ describe('Assignees', (): void => {
             optionsInterface.exemptPrAssignees = 'dummy-exempt-pr-assignee';
           });
 
-          describe('when the given issue does not have an assignee', (): void => {
+          describe('when the given pull request does not have an assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [];
             });
@@ -378,7 +507,7 @@ describe('Assignees', (): void => {
             });
           });
 
-          describe('when the given issue does have an assignee different than the exempt pull request assignee', (): void => {
+          describe('when the given pull request does have an assignee different than the exempt pull request assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [
                 {
@@ -398,7 +527,7 @@ describe('Assignees', (): void => {
             });
           });
 
-          describe('when the given issue does have an assignee equaling the exempt pull request assignee', (): void => {
+          describe('when the given pull request does have an assignee equaling the exempt pull request assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [
                 {
@@ -430,7 +559,7 @@ describe('Assignees', (): void => {
             optionsInterface.exemptPrAssignees = '';
           });
 
-          describe('when the given issue does not have an assignee', (): void => {
+          describe('when the given pull request does not have an assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [];
             });
@@ -446,7 +575,7 @@ describe('Assignees', (): void => {
             });
           });
 
-          describe('when the given issue does have an assignee different than the exempt assignee', (): void => {
+          describe('when the given pull request does have an assignee different than the exempt assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [
                 {
@@ -466,7 +595,7 @@ describe('Assignees', (): void => {
             });
           });
 
-          describe('when the given issue does have an assignee equaling the exempt assignee', (): void => {
+          describe('when the given pull request does have an assignee equaling the exempt assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [
                 {
@@ -492,7 +621,7 @@ describe('Assignees', (): void => {
             optionsInterface.exemptPrAssignees = 'dummy-exempt-pr-assignee';
           });
 
-          describe('when the given issue does not have an assignee', (): void => {
+          describe('when the given pull request does not have an assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [];
             });
@@ -508,7 +637,7 @@ describe('Assignees', (): void => {
             });
           });
 
-          describe('when the given issue does have an assignee different than the exempt pull request assignee', (): void => {
+          describe('when the given pull request does have an assignee different than the exempt pull request assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [
                 {
@@ -528,7 +657,7 @@ describe('Assignees', (): void => {
             });
           });
 
-          describe('when the given issue does have an assignee equaling the exempt pull request assignee', (): void => {
+          describe('when the given pull request does have an assignee equaling the exempt pull request assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [
                 {
@@ -548,7 +677,7 @@ describe('Assignees', (): void => {
             });
           });
 
-          describe('when the given issue does have an assignee different than the exempt assignee', (): void => {
+          describe('when the given pull request does have an assignee different than the exempt assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [
                 {
@@ -568,7 +697,7 @@ describe('Assignees', (): void => {
             });
           });
 
-          describe('when the given issue does have an assignee equaling the exempt assignee', (): void => {
+          describe('when the given pull request does have an assignee equaling the exempt assignee', (): void => {
             beforeEach((): void => {
               issueInterface.assignees = [
                 {
@@ -585,6 +714,132 @@ describe('Assignees', (): void => {
               const result = assignees.shouldExemptAssignees();
 
               expect(result).toStrictEqual(false);
+            });
+          });
+        });
+      });
+
+      describe('when the given options are configured to exempt all assignees', (): void => {
+        beforeEach((): void => {
+          optionsInterface.exemptAllAssignees = true;
+        });
+
+        describe('when the given pull request does not have an assignee', (): void => {
+          beforeEach((): void => {
+            issueInterface.assignees = [];
+          });
+
+          it('should return false', (): void => {
+            expect.assertions(1);
+            issue = new Issue(optionsInterface, issueInterface);
+            assignees = new Assignees(optionsInterface, issue);
+
+            const result = assignees.shouldExemptAssignees();
+
+            expect(result).toStrictEqual(false);
+          });
+        });
+
+        describe('when the given pull request does have an assignee', (): void => {
+          beforeEach((): void => {
+            issueInterface.assignees = [
+              {
+                login: 'dummy-exempt-assignee'
+              }
+            ];
+          });
+
+          it('should return true', (): void => {
+            expect.assertions(1);
+            issue = new Issue(optionsInterface, issueInterface);
+            assignees = new Assignees(optionsInterface, issue);
+
+            const result = assignees.shouldExemptAssignees();
+
+            expect(result).toStrictEqual(true);
+          });
+        });
+
+        describe('when the given options are not configured to exempt all pull request assignees', (): void => {
+          beforeEach((): void => {
+            optionsInterface.exemptAllPrAssignees = false;
+          });
+
+          describe('when the given pull request does not have an assignee', (): void => {
+            beforeEach((): void => {
+              issueInterface.assignees = [];
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              assignees = new Assignees(optionsInterface, issue);
+
+              const result = assignees.shouldExemptAssignees();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+
+          describe('when the given pull request does have an assignee', (): void => {
+            beforeEach((): void => {
+              issueInterface.assignees = [
+                {
+                  login: 'dummy-exempt-assignee'
+                }
+              ];
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              assignees = new Assignees(optionsInterface, issue);
+
+              const result = assignees.shouldExemptAssignees();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+        });
+
+        describe('when the given options are configured to exempt all pull request assignees', (): void => {
+          beforeEach((): void => {
+            optionsInterface.exemptAllPrAssignees = true;
+          });
+
+          describe('when the given pull request does not have an assignee', (): void => {
+            beforeEach((): void => {
+              issueInterface.assignees = [];
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              assignees = new Assignees(optionsInterface, issue);
+
+              const result = assignees.shouldExemptAssignees();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+
+          describe('when the given pull request does have an assignee', (): void => {
+            beforeEach((): void => {
+              issueInterface.assignees = [
+                {
+                  login: 'dummy-exempt-issue-assignee'
+                }
+              ];
+            });
+
+            it('should return true', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              assignees = new Assignees(optionsInterface, issue);
+
+              const result = assignees.shouldExemptAssignees();
+
+              expect(result).toStrictEqual(true);
             });
           });
         });

--- a/src/classes/assignees.ts
+++ b/src/classes/assignees.ts
@@ -1,4 +1,6 @@
+import chalk from 'chalk';
 import deburr from 'lodash.deburr';
+import {Option} from '../enums/option';
 import {wordsToList} from '../functions/words-to-list';
 import {IAssignee} from '../interfaces/assignee';
 import {IIssuesProcessorOptions} from '../interfaces/issues-processor-options';
@@ -32,6 +34,7 @@ export class Assignees {
 
     if (this._shouldExemptAllAssignees()) {
       this._issueLogger.info(
+        chalk.white('└──'),
         'Skipping $$type because it has an exempt assignee'
       );
 
@@ -42,6 +45,7 @@ export class Assignees {
 
     if (exemptAssignees.length === 0) {
       this._issueLogger.info(
+        chalk.white('├──'),
         `No assignee option was specified to skip the stale process for this $$type`
       );
       this._logSkip();
@@ -50,7 +54,8 @@ export class Assignees {
     }
 
     this._issueLogger.info(
-      `Found ${exemptAssignees.length} assignee${
+      chalk.white('├──'),
+      `Found ${chalk.cyan(exemptAssignees.length)} assignee${
         exemptAssignees.length > 1 ? 's' : ''
       } that can exempt stale on this $$type`
     );
@@ -62,11 +67,13 @@ export class Assignees {
 
     if (!hasExemptAssignee) {
       this._issueLogger.info(
+        chalk.white('├──'),
         'No assignee on this $$type can exempt the stale process'
       );
       this._logSkip();
     } else {
       this._issueLogger.info(
+        chalk.white('└──'),
         'Skipping this $$type because it has an exempt assignee'
       );
     }
@@ -83,12 +90,18 @@ export class Assignees {
   private _getExemptIssueAssignees(): string[] {
     if (this._options.exemptIssueAssignees === '') {
       this._issueLogger.info(
-        'The option "exemptIssueAssignees" is disabled. No specific assignee can skip the stale process for this $$type'
+        chalk.white('├──'),
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptIssueAssignees
+        )} is disabled. No specific assignee can skip the stale process for this $$type`
       );
 
       if (this._options.exemptAssignees === '') {
         this._issueLogger.info(
-          'The option "exemptAssignees" is disabled. No specific assignee can skip the stale process for this $$type'
+          chalk.white('├──'),
+          `The option ${this._issueLogger.createOptionLink(
+            Option.ExemptAssignees
+          )} is disabled. No specific assignee can skip the stale process for this $$type`
         );
 
         return [];
@@ -99,9 +112,10 @@ export class Assignees {
       );
 
       this._issueLogger.info(
-        `The option "exemptAssignees" is set. ${
-          exemptAssignees.length
-        } assignee${
+        chalk.white('├──'),
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAssignees
+        )} is set. ${chalk.cyan(exemptAssignees.length)} assignee${
           exemptAssignees.length === 1 ? '' : 's'
         } can skip the stale process for this $$type`
       );
@@ -114,9 +128,10 @@ export class Assignees {
     );
 
     this._issueLogger.info(
-      `The option "exemptIssueAssignees" is set. ${
-        exemptAssignees.length
-      } assignee${
+      chalk.white('├──'),
+      `The option ${this._issueLogger.createOptionLink(
+        Option.ExemptIssueAssignees
+      )} is set. ${chalk.cyan(exemptAssignees.length)} assignee${
         exemptAssignees.length === 1 ? '' : 's'
       } can skip the stale process for this $$type`
     );
@@ -127,12 +142,18 @@ export class Assignees {
   private _getExemptPullRequestAssignees(): string[] {
     if (this._options.exemptPrAssignees === '') {
       this._issueLogger.info(
-        'The option "exemptPrAssignees" is disabled. No specific assignee can skip the stale process for this $$type'
+        chalk.white('├──'),
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptPrAssignees
+        )} is disabled. No specific assignee can skip the stale process for this $$type`
       );
 
       if (this._options.exemptAssignees === '') {
         this._issueLogger.info(
-          'The option "exemptAssignees" is disabled. No specific assignee can skip the stale process for this $$type'
+          chalk.white('├──'),
+          `The option ${this._issueLogger.createOptionLink(
+            Option.ExemptAssignees
+          )} is disabled. No specific assignee can skip the stale process for this $$type`
         );
 
         return [];
@@ -143,9 +164,10 @@ export class Assignees {
       );
 
       this._issueLogger.info(
-        `The option "exemptAssignees" is set. ${
-          exemptAssignees.length
-        } assignee${
+        chalk.white('├──'),
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAssignees
+        )} is set. ${chalk.cyan(exemptAssignees.length)} assignee${
           exemptAssignees.length === 1 ? '' : 's'
         } can skip the stale process for this $$type`
       );
@@ -158,9 +180,10 @@ export class Assignees {
     );
 
     this._issueLogger.info(
-      `The option "exemptPrAssignees" is set. ${
-        exemptAssignees.length
-      } assignee${
+      chalk.white('├──'),
+      `The option ${this._issueLogger.createOptionLink(
+        Option.ExemptPrAssignees
+      )} is set. ${chalk.cyan(exemptAssignees.length)} assignee${
         exemptAssignees.length === 1 ? '' : 's'
       } can skip the stale process for this $$type`
     );
@@ -178,6 +201,7 @@ export class Assignees {
 
         if (isSameAssignee) {
           this._issueLogger.info(
+            chalk.white('├──'),
             `@${issueAssignee.login} is assigned on this $$type and is an exempt assignee`
           );
         }
@@ -196,13 +220,17 @@ export class Assignees {
   private _shouldExemptAllIssueAssignees(): boolean {
     if (this._options.exemptAllIssueAssignees === true) {
       this._issueLogger.info(
-        'The option "exemptAllIssueAssignees" is enabled. Any assignee on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllIssueAssignees
+        )} is enabled. Any assignee on this $$type will skip the stale process`
       );
 
       return true;
     } else if (this._options.exemptAllIssueAssignees === false) {
       this._issueLogger.info(
-        'The option "exemptAllIssueAssignees" is disabled. Only some specific assignees on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllIssueAssignees
+        )} is disabled. Only some specific assignees on this $$type will skip the stale process`
       );
 
       return false;
@@ -216,13 +244,17 @@ export class Assignees {
   private _shouldExemptAllPullRequestAssignees(): boolean {
     if (this._options.exemptAllPrAssignees === true) {
       this._issueLogger.info(
-        'The option "exemptAllPrAssignees" is enabled. Any assignee on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllPrAssignees
+        )} is enabled. Any assignee on this $$type will skip the stale process`
       );
 
       return true;
     } else if (this._options.exemptAllPrAssignees === false) {
       this._issueLogger.info(
-        'The option "exemptAllPrAssignees" is disabled. Only some specific assignees on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllPrAssignees
+        )} is disabled. Only some specific assignees on this $$type will skip the stale process`
       );
 
       return false;
@@ -236,16 +268,20 @@ export class Assignees {
   private _logExemptAllAssigneesOption(): void {
     if (this._options.exemptAllAssignees) {
       this._issueLogger.info(
-        'The option "exemptAllAssignees" is enabled. Any assignee on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllAssignees
+        )} is enabled. Any assignee on this $$type will skip the stale process`
       );
     } else {
       this._issueLogger.info(
-        'The option "exemptAllAssignees" is disabled. Only some specific assignees on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllAssignees
+        )} is disabled. Only some specific assignees on this $$type will skip the stale process`
       );
     }
   }
 
   private _logSkip(): void {
-    this._issueLogger.info('Skip the assignees checks');
+    this._issueLogger.info(chalk.white('└──'), 'Skip the assignees checks');
   }
 }

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -31,6 +31,8 @@ describe('Issue', (): void => {
       onlyIssueLabels: '',
       onlyPrLabels: '',
       anyOfLabels: '',
+      anyOfIssueLabels: '',
+      anyOfPrLabels: '',
       operationsPerRun: 0,
       removeStaleWhenUpdated: false,
       repoToken: '',

--- a/src/classes/milestones.spec.ts
+++ b/src/classes/milestones.spec.ts
@@ -12,7 +12,7 @@ describe('Milestones', (): void => {
   let issueInterface: IIssue;
 
   beforeEach((): void => {
-    optionsInterface = {...DefaultProcessorOptions};
+    optionsInterface = {...DefaultProcessorOptions, exemptAllMilestones: false};
     issueInterface = generateIIssue();
   });
 
@@ -285,21 +285,49 @@ describe('Milestones', (): void => {
           });
         });
       });
-    });
 
-    describe('when the given issue is a pull request', (): void => {
-      beforeEach((): void => {
-        issueInterface.pull_request = {};
-      });
-
-      describe('when the given options are not configured to exempt a milestone', (): void => {
+      describe('when the given options are configured to exempt all milestones', (): void => {
         beforeEach((): void => {
-          optionsInterface.exemptMilestones = '';
+          optionsInterface.exemptAllMilestones = true;
         });
 
-        describe('when the given options are not configured to exempt a pull request milestone', (): void => {
+        describe('when the given issue does not have a milestone', (): void => {
           beforeEach((): void => {
-            optionsInterface.exemptPrMilestones = '';
+            issueInterface.milestone = undefined;
+          });
+
+          it('should return false', (): void => {
+            expect.assertions(1);
+            issue = new Issue(optionsInterface, issueInterface);
+            milestones = new Milestones(optionsInterface, issue);
+
+            const result = milestones.shouldExemptMilestones();
+
+            expect(result).toStrictEqual(false);
+          });
+        });
+
+        describe('when the given issue does have a milestone', (): void => {
+          beforeEach((): void => {
+            issueInterface.milestone = {
+              title: 'dummy-exempt-issue-milestone'
+            };
+          });
+
+          it('should return true', (): void => {
+            expect.assertions(1);
+            issue = new Issue(optionsInterface, issueInterface);
+            milestones = new Milestones(optionsInterface, issue);
+
+            const result = milestones.shouldExemptMilestones();
+
+            expect(result).toStrictEqual(true);
+          });
+        });
+
+        describe('when the given options are not configured to exempt all issue milestones', (): void => {
+          beforeEach((): void => {
+            optionsInterface.exemptAllIssueMilestones = false;
           });
 
           describe('when the given issue does not have a milestone', (): void => {
@@ -319,6 +347,98 @@ describe('Milestones', (): void => {
           });
 
           describe('when the given issue does have a milestone', (): void => {
+            beforeEach((): void => {
+              issueInterface.milestone = {
+                title: 'dummy-exempt-milestone'
+              };
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              milestones = new Milestones(optionsInterface, issue);
+
+              const result = milestones.shouldExemptMilestones();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+        });
+
+        describe('when the given options are configured to exempt all issue milestones', (): void => {
+          beforeEach((): void => {
+            optionsInterface.exemptAllIssueMilestones = true;
+          });
+
+          describe('when the given issue does not have a milestone', (): void => {
+            beforeEach((): void => {
+              issueInterface.milestone = undefined;
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              milestones = new Milestones(optionsInterface, issue);
+
+              const result = milestones.shouldExemptMilestones();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+
+          describe('when the given issue does have a milestone', (): void => {
+            beforeEach((): void => {
+              issueInterface.milestone = {
+                title: 'dummy-exempt-issue-milestone'
+              };
+            });
+
+            it('should return true', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              milestones = new Milestones(optionsInterface, issue);
+
+              const result = milestones.shouldExemptMilestones();
+
+              expect(result).toStrictEqual(true);
+            });
+          });
+        });
+      });
+    });
+
+    describe('when the given issue is a pull request', (): void => {
+      beforeEach((): void => {
+        issueInterface.pull_request = {};
+      });
+
+      describe('when the given options are not configured to exempt a milestone', (): void => {
+        beforeEach((): void => {
+          optionsInterface.exemptMilestones = '';
+        });
+
+        describe('when the given options are not configured to exempt a pull request milestone', (): void => {
+          beforeEach((): void => {
+            optionsInterface.exemptPrMilestones = '';
+          });
+
+          describe('when the given pull request does not have a milestone', (): void => {
+            beforeEach((): void => {
+              issueInterface.milestone = undefined;
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              milestones = new Milestones(optionsInterface, issue);
+
+              const result = milestones.shouldExemptMilestones();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+
+          describe('when the given pull request does have a milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = {
                 title: 'dummy-title'
@@ -342,7 +462,7 @@ describe('Milestones', (): void => {
             optionsInterface.exemptPrMilestones = 'dummy-exempt-pr-milestone';
           });
 
-          describe('when the given issue does not have a milestone', (): void => {
+          describe('when the given pull request does not have a milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = undefined;
             });
@@ -358,7 +478,7 @@ describe('Milestones', (): void => {
             });
           });
 
-          describe('when the given issue does have a milestone different than the exempt pull request milestone', (): void => {
+          describe('when the given pull request does have a milestone different than the exempt pull request milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = {
                 title: 'dummy-title'
@@ -376,7 +496,7 @@ describe('Milestones', (): void => {
             });
           });
 
-          describe('when the given issue does have a milestone equaling the exempt pull request milestone', (): void => {
+          describe('when the given pull request does have a milestone equaling the exempt pull request milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = {
                 title: 'dummy-exempt-pr-milestone'
@@ -406,7 +526,7 @@ describe('Milestones', (): void => {
             optionsInterface.exemptPrMilestones = '';
           });
 
-          describe('when the given issue does not have a milestone', (): void => {
+          describe('when the given pull request does not have a milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = undefined;
             });
@@ -422,7 +542,7 @@ describe('Milestones', (): void => {
             });
           });
 
-          describe('when the given issue does have a milestone different than the exempt milestone', (): void => {
+          describe('when the given pull request does have a milestone different than the exempt milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = {
                 title: 'dummy-title'
@@ -440,7 +560,7 @@ describe('Milestones', (): void => {
             });
           });
 
-          describe('when the given issue does have a milestone equaling the exempt milestone', (): void => {
+          describe('when the given pull request does have a milestone equaling the exempt milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = {
                 title: 'dummy-exempt-milestone'
@@ -464,7 +584,7 @@ describe('Milestones', (): void => {
             optionsInterface.exemptPrMilestones = 'dummy-exempt-pr-milestone';
           });
 
-          describe('when the given issue does not have a milestone', (): void => {
+          describe('when the given pull request does not have a milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = undefined;
             });
@@ -480,7 +600,7 @@ describe('Milestones', (): void => {
             });
           });
 
-          describe('when the given issue does have a milestone different than the exempt pull request milestone', (): void => {
+          describe('when the given pull request does have a milestone different than the exempt pull request milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = {
                 title: 'dummy-title'
@@ -498,7 +618,7 @@ describe('Milestones', (): void => {
             });
           });
 
-          describe('when the given issue does have a milestone equaling the exempt pull request milestone', (): void => {
+          describe('when the given pull request does have a milestone equaling the exempt pull request milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = {
                 title: 'dummy-exempt-pr-milestone'
@@ -516,7 +636,7 @@ describe('Milestones', (): void => {
             });
           });
 
-          describe('when the given issue does have a milestone different than the exempt milestone', (): void => {
+          describe('when the given pull request does have a milestone different than the exempt milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = {
                 title: 'dummy-title'
@@ -534,7 +654,7 @@ describe('Milestones', (): void => {
             });
           });
 
-          describe('when the given issue does have a milestone equaling the exempt milestone', (): void => {
+          describe('when the given pull request does have a milestone equaling the exempt milestone', (): void => {
             beforeEach((): void => {
               issueInterface.milestone = {
                 title: 'dummy-exempt-milestone'
@@ -549,6 +669,126 @@ describe('Milestones', (): void => {
               const result = milestones.shouldExemptMilestones();
 
               expect(result).toStrictEqual(false);
+            });
+          });
+        });
+      });
+
+      describe('when the given options are configured to exempt all milestones', (): void => {
+        beforeEach((): void => {
+          optionsInterface.exemptAllMilestones = true;
+        });
+
+        describe('when the given pull request does not have a milestone', (): void => {
+          beforeEach((): void => {
+            issueInterface.milestone = undefined;
+          });
+
+          it('should return false', (): void => {
+            expect.assertions(1);
+            issue = new Issue(optionsInterface, issueInterface);
+            milestones = new Milestones(optionsInterface, issue);
+
+            const result = milestones.shouldExemptMilestones();
+
+            expect(result).toStrictEqual(false);
+          });
+        });
+
+        describe('when the given pull request does have a milestone', (): void => {
+          beforeEach((): void => {
+            issueInterface.milestone = {
+              title: 'dummy-exempt-pr-milestone'
+            };
+          });
+
+          it('should return true', (): void => {
+            expect.assertions(1);
+            issue = new Issue(optionsInterface, issueInterface);
+            milestones = new Milestones(optionsInterface, issue);
+
+            const result = milestones.shouldExemptMilestones();
+
+            expect(result).toStrictEqual(true);
+          });
+        });
+
+        describe('when the given options are not configured to exempt all pull request milestones', (): void => {
+          beforeEach((): void => {
+            optionsInterface.exemptAllPrMilestones = false;
+          });
+
+          describe('when the given pull request does not have a milestone', (): void => {
+            beforeEach((): void => {
+              issueInterface.milestone = undefined;
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              milestones = new Milestones(optionsInterface, issue);
+
+              const result = milestones.shouldExemptMilestones();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+
+          describe('when the given pull request does have a milestone', (): void => {
+            beforeEach((): void => {
+              issueInterface.milestone = {
+                title: 'dummy-exempt-milestone'
+              };
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              milestones = new Milestones(optionsInterface, issue);
+
+              const result = milestones.shouldExemptMilestones();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+        });
+
+        describe('when the given options are configured to exempt all pull request milestones', (): void => {
+          beforeEach((): void => {
+            optionsInterface.exemptAllPrMilestones = true;
+          });
+
+          describe('when the given pull request does not have a milestone', (): void => {
+            beforeEach((): void => {
+              issueInterface.milestone = undefined;
+            });
+
+            it('should return false', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              milestones = new Milestones(optionsInterface, issue);
+
+              const result = milestones.shouldExemptMilestones();
+
+              expect(result).toStrictEqual(false);
+            });
+          });
+
+          describe('when the given pull request does have a milestone', (): void => {
+            beforeEach((): void => {
+              issueInterface.milestone = {
+                title: 'dummy-exempt-pr-milestone'
+              };
+            });
+
+            it('should return true', (): void => {
+              expect.assertions(1);
+              issue = new Issue(optionsInterface, issueInterface);
+              milestones = new Milestones(optionsInterface, issue);
+
+              const result = milestones.shouldExemptMilestones();
+
+              expect(result).toStrictEqual(true);
             });
           });
         });

--- a/src/classes/milestones.ts
+++ b/src/classes/milestones.ts
@@ -1,4 +1,6 @@
+import chalk from 'chalk';
 import deburr from 'lodash.deburr';
+import {Option} from '../enums/option';
 import {wordsToList} from '../functions/words-to-list';
 import {IIssuesProcessorOptions} from '../interfaces/issues-processor-options';
 import {Issue} from './issue';
@@ -31,7 +33,8 @@ export class Milestones {
 
     if (this._shouldExemptAllMilestones()) {
       this._issueLogger.info(
-        'Skipping $$type because it has an exempt milestone'
+        chalk.white('└──'),
+        'Skipping $$type because it has a milestone'
       );
 
       return true;
@@ -41,6 +44,7 @@ export class Milestones {
 
     if (exemptMilestones.length === 0) {
       this._issueLogger.info(
+        chalk.white('├──'),
         `No milestone option was specified to skip the stale process for this $$type`
       );
       this._logSkip();
@@ -49,7 +53,8 @@ export class Milestones {
     }
 
     this._issueLogger.info(
-      `Found ${exemptMilestones.length} milestone${
+      chalk.white('├──'),
+      `Found ${chalk.cyan(exemptMilestones.length)} milestone${
         exemptMilestones.length > 1 ? 's' : ''
       } that can exempt stale on this $$type`
     );
@@ -61,11 +66,13 @@ export class Milestones {
 
     if (!hasExemptMilestone) {
       this._issueLogger.info(
+        chalk.white('├──'),
         'No milestone on this $$type can exempt the stale process'
       );
       this._logSkip();
     } else {
       this._issueLogger.info(
+        chalk.white('└──'),
         'Skipping this $$type because it has an exempt milestone'
       );
     }
@@ -82,12 +89,18 @@ export class Milestones {
   private _getExemptIssueMilestones(): string[] {
     if (this._options.exemptIssueMilestones === '') {
       this._issueLogger.info(
-        'The option "exemptIssueMilestones" is disabled. No specific milestone can skip the stale process for this $$type'
+        chalk.white('├──'),
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptIssueMilestones
+        )} is disabled. No specific milestone can skip the stale process for this $$type`
       );
 
       if (this._options.exemptMilestones === '') {
         this._issueLogger.info(
-          'The option "exemptMilestones" is disabled. No specific milestone can skip the stale process for this $$type'
+          chalk.white('├──'),
+          `The option ${this._issueLogger.createOptionLink(
+            Option.ExemptMilestones
+          )} is disabled. No specific milestone can skip the stale process for this $$type`
         );
 
         return [];
@@ -98,9 +111,10 @@ export class Milestones {
       );
 
       this._issueLogger.info(
-        `The option "exemptMilestones" is set. ${
-          exemptMilestones.length
-        } milestone${
+        chalk.white('├──'),
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptMilestones
+        )} is set. ${chalk.cyan(exemptMilestones.length)} milestone${
           exemptMilestones.length === 1 ? '' : 's'
         } can skip the stale process for this $$type`
       );
@@ -113,9 +127,10 @@ export class Milestones {
     );
 
     this._issueLogger.info(
-      `The option "exemptIssueMilestones" is set. ${
-        exemptMilestones.length
-      } milestone${
+      chalk.white('├──'),
+      `The option ${this._issueLogger.createOptionLink(
+        Option.ExemptIssueMilestones
+      )} is set. ${chalk.cyan(exemptMilestones.length)} milestone${
         exemptMilestones.length === 1 ? '' : 's'
       } can skip the stale process for this $$type`
     );
@@ -126,12 +141,18 @@ export class Milestones {
   private _getExemptPullRequestMilestones(): string[] {
     if (this._options.exemptPrMilestones === '') {
       this._issueLogger.info(
-        'The option "exemptPrMilestones" is disabled. No specific milestone can skip the stale process for this $$type'
+        chalk.white('├──'),
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptPrMilestones
+        )} is disabled. No specific milestone can skip the stale process for this $$type`
       );
 
       if (this._options.exemptMilestones === '') {
         this._issueLogger.info(
-          'The option "exemptMilestones" is disabled. No specific milestone can skip the stale process for this $$type'
+          chalk.white('├──'),
+          `The option ${this._issueLogger.createOptionLink(
+            Option.ExemptMilestones
+          )} is disabled. No specific milestone can skip the stale process for this $$type`
         );
 
         return [];
@@ -142,9 +163,10 @@ export class Milestones {
       );
 
       this._issueLogger.info(
-        `The option "exemptMilestones" is set. ${
-          exemptMilestones.length
-        } milestone${
+        chalk.white('├──'),
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptMilestones
+        )} is set. ${chalk.cyan(exemptMilestones.length)} milestone${
           exemptMilestones.length === 1 ? '' : 's'
         } can skip the stale process for this $$type`
       );
@@ -157,9 +179,10 @@ export class Milestones {
     );
 
     this._issueLogger.info(
-      `The option "exemptPrMilestones" is set. ${
-        exemptMilestones.length
-      } milestone${
+      chalk.white('├──'),
+      `The option ${this._issueLogger.createOptionLink(
+        Option.ExemptPrMilestones
+      )} is set. ${chalk.cyan(exemptMilestones.length)} milestone${
         exemptMilestones.length === 1 ? '' : 's'
       } can skip the stale process for this $$type`
     );
@@ -182,6 +205,7 @@ export class Milestones {
 
     if (isSameMilestone) {
       this._issueLogger.info(
+        chalk.white('├──'),
         `The milestone "${milestone}" is set on this $$type and is an exempt milestone`
       );
     }
@@ -202,13 +226,17 @@ export class Milestones {
   private _shouldExemptAllIssueMilestones(): boolean {
     if (this._options.exemptAllIssueMilestones === true) {
       this._issueLogger.info(
-        'The option "exemptAllIssueMilestones" is enabled. Any milestone on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllIssueMilestones
+        )} is enabled. Any milestone on this $$type will skip the stale process`
       );
 
       return true;
     } else if (this._options.exemptAllIssueMilestones === false) {
       this._issueLogger.info(
-        'The option "exemptAllIssueMilestones" is disabled. Only some specific milestones on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllIssueMilestones
+        )} is disabled. Only some specific milestones on this $$type will skip the stale process`
       );
 
       return false;
@@ -222,13 +250,17 @@ export class Milestones {
   private _shouldExemptAllPullRequestMilestones(): boolean {
     if (this._options.exemptAllPrMilestones === true) {
       this._issueLogger.info(
-        'The option "exemptAllPrMilestones" is enabled. Any milestone on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllPrMilestones
+        )} is enabled. Any milestone on this $$type will skip the stale process`
       );
 
       return true;
     } else if (this._options.exemptAllPrMilestones === false) {
       this._issueLogger.info(
-        'The option "exemptAllPrMilestones" is disabled. Only some specific milestones on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllPrMilestones
+        )} is disabled. Only some specific milestones on this $$type will skip the stale process`
       );
 
       return false;
@@ -242,16 +274,20 @@ export class Milestones {
   private _logExemptAllMilestonesOption(): void {
     if (this._options.exemptAllMilestones) {
       this._issueLogger.info(
-        'The option "exemptAllMilestones" is enabled. Any milestone on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllMilestones
+        )} is enabled. Any milestone on this $$type will skip the stale process`
       );
     } else {
       this._issueLogger.info(
-        'The option "exemptAllMilestones" is disabled. Only some specific milestones on this $$type will skip the stale process'
+        `The option ${this._issueLogger.createOptionLink(
+          Option.ExemptAllMilestones
+        )} is disabled. Only some specific milestones on this $$type will skip the stale process`
       );
     }
   }
 
   private _logSkip(): void {
-    this._issueLogger.info('Skip the milestones checks');
+    this._issueLogger.info(chalk.white('└──'), 'Skip the milestones checks');
   }
 }

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -22,6 +22,8 @@ export interface IIssuesProcessorOptions {
   onlyIssueLabels: string;
   onlyPrLabels: string;
   anyOfLabels: string;
+  anyOfIssueLabels: string;
+  anyOfPrLabels: string;
   operationsPerRun: number;
   removeStaleWhenUpdated: boolean;
   debugOnly: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,8 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     onlyIssueLabels: core.getInput('only-issue-labels'),
     onlyPrLabels: core.getInput('only-pr-labels'),
     anyOfLabels: core.getInput('any-of-labels'),
+    anyOfIssueLabels: core.getInput('any-of-issue-labels'),
+    anyOfPrLabels: core.getInput('any-of-pr-labels'),
     operationsPerRun: parseInt(
       core.getInput('operations-per-run', {required: true})
     ),


### PR DESCRIPTION
Not tests but feels like a typo.

Or if we keep the title it `exempt` feels more approriate:

          exempt-issue-labels: 'roadmap'
          exempt-pr-labels: 'roadmap'