### PR TITLE
feat(logs): add a new log when an issue consumed at least one operati…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Every argument is optional.
 
 | Input                             | Description                                                                                                                                                   |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `repo-token`                      | PAT(Personal Access Token) for authorizing repository.<br>_Defaults to **${{ github.token }}**_.                                                              |
+| `repo-token`                      | PAT (Personal Access Token) for authorizing the repository.<br>_Defaults to **${{ github.token }}**_.                                                         |
 | `days-before-stale`               | Idle number of days before marking an issue/PR as stale.<br>_Defaults to **60**_.                                                                             |
 | `days-before-issue-stale`         | Idle number of days before marking an issue as stale.<br>_Override `days-before-stale`_.                                                                      |
 | `days-before-pr-stale`            | Idle number of days before marking an PR as stale.<br>_Override `days-before-stale`_.                                                                         |
@@ -37,6 +37,8 @@ Every argument is optional.
 | `remove-stale-when-updated`       | Remove stale label from issue/PR on updates or comments.<br>_Defaults to **true**_.                                                                           |
 | `remove-issue-stale-when-updated` | Remove stale label from issue on updates or comments.<br>_Defaults to **true**_.<br>_Override `remove-stale-when-updated`_.                                   |
 | `remove-pr-stale-when-updated`    | Remove stale label from PR on updates or comments.<br>_Defaults to **true**_.<br>_Override `remove-stale-when-updated`_.                                      |
+| `remove-issue-stale-when-updated` | Remove stale label from issue on updates or comments.<br>_Defaults to **true**_.<br>_Override `remove-stale-when-updated`_.                                   |
+| `remove-pr-stale-when-updated`    | Remove stale label from PR on updates or comments.<br>_Defaults to **true**_.<br>_Override `remove-stale-when-updated`_.                                      |
 | `debug-only`                      | Dry-run on action.<br>_Defaults to **false**_.                                                                                                                |
 | `ascending`                       | Order to get issues/PR.<br>`true` is ascending, `false` is descending.<br>_Defaults to **false**_.                                                            |
 | `skip-stale-issue-message`        | Skip adding stale message on stale issue.<br>_Defaults to **false**_.                                                                                         |
@@ -61,11 +63,22 @@ Every argument is optional.
 
 #### operations-per-run
 
-Used to limit the number of operations made with the GitHub API to avoid reaching the [rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting).  
+_Context:_  
+This action performs some API calls to GitHub to fetch or close issues and pull requests, set or update labels, add comments, delete branches, etc.  
+These operations are made in a very short period of time - because the action is very fast to run - and can be numerous based on your project action configuration and the quantity of issues and pull requests within it.  
+GitHub has a [rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting) and if reached will block all of these API calls for one hour (or API calls from other actions using the same user (a.k.a: the github-token from the [repo-token](#repo-token) option)).  
+This option helps you to stay within the GitHub rate limits, as you can use this option to limit the number of operations for a single run.
+
+_Purpose:_  
+This option aims to limit the number of operations made with the GitHub API to avoid reaching the [rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting).
+
 Based on your project, your GitHub business plan and the date of the cron job you set for this action, you can increase this limit to a higher number.
+If you are not sure which is the right value for you or if the default value is good enough, you could enable the logs and look at the end of the stale action.  
+If you reached the limit, you will see a warning message in the logs, telling you that you should increase the number of operations.
+If you choose not to increase the limit, you might end up with un-processed issues or pull requests after a stale action run.
 
 When [debugging](#Debugging), you can set it to a much higher number like `1000` since there will be fewer operations made with the GitHub API.  
-Only the actor and the batch of issues (100 per batch) will consume the operations.
+Only the [actor](#repo-token) and the batch of issues (100 per batch) will consume the operations.
 
 Default value: `30`
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,5 +7,6 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },
-  verbose: true
+  verbose: true,
+  setupFilesAfterEnv: [`./jest/test.ts`]
 };

--- a/jest/test.ts
+++ b/jest/test.ts
@@ -1,0 +1,11 @@
+import chalk from 'chalk';
+
+// Disabled the colors to:
+// - improve the performances
+// - avoid to mock chalk
+// - avoid to have failing tests when testing the logs due to the extra text the log message will contains
+//
+// Note:
+// If you need to debug the log colours you can remove this line temporarily
+// But some tests will fail
+chalk.level = 0;

--- a/src/classes/issue.ts
+++ b/src/classes/issue.ts
@@ -6,6 +6,7 @@ import {IIssuesProcessorOptions} from '../interfaces/issues-processor-options';
 import {ILabel} from '../interfaces/label';
 import {IMilestone} from '../interfaces/milestone';
 import {IsoDateString} from '../types/iso-date-string';
+import {Operations} from './operations';
 
 export class Issue implements IIssue {
   private readonly _options: IIssuesProcessorOptions;
@@ -20,6 +21,19 @@ export class Issue implements IIssue {
   readonly milestone: IMilestone | undefined;
   readonly assignees: IAssignee[];
   isStale: boolean;
+  operations = new Operations();
+
+  get isPullRequest(): boolean {
+    return isPullRequest(this);
+  }
+
+  get staleLabel(): string {
+    return this._getStaleLabel();
+  }
+
+  get hasAssignees(): boolean {
+    return this.assignees.length > 0;
+  }
 
   constructor(
     options: Readonly<IIssuesProcessorOptions>,
@@ -38,18 +52,6 @@ export class Issue implements IIssue {
     this.assignees = issue.assignees;
 
     this.isStale = isLabeled(this, this.staleLabel);
-  }
-
-  get isPullRequest(): boolean {
-    return isPullRequest(this);
-  }
-
-  get staleLabel(): string {
-    return this._getStaleLabel();
-  }
-
-  get hasAssignees(): boolean {
-    return this.assignees.length > 0;
   }
 
   private _getStaleLabel(): string {

--- a/src/classes/operations.spec.ts
+++ b/src/classes/operations.spec.ts
@@ -1,0 +1,49 @@
+import {Operations} from './operations';
+
+describe('Operations', (): void => {
+  let operations: Operations;
+
+  describe('consumeOperation()', (): void => {
+    beforeEach((): void => {
+      operations = new Operations();
+    });
+
+    it('should increase the count of operation consume by 1', (): void => {
+      expect.assertions(1);
+      operations.consumeOperation();
+
+      const result = operations.getConsumedOperationsCount();
+
+      expect(result).toStrictEqual(1);
+    });
+  });
+
+  describe('consumeOperations()', (): void => {
+    beforeEach((): void => {
+      operations = new Operations();
+    });
+
+    it('should increase the count of operation consume by the provided quantity', (): void => {
+      expect.assertions(1);
+      operations.consumeOperations(8);
+
+      const result = operations.getConsumedOperationsCount();
+
+      expect(result).toStrictEqual(8);
+    });
+  });
+
+  describe('getConsumedOperationsCount()', (): void => {
+    beforeEach((): void => {
+      operations = new Operations();
+    });
+
+    it('should return 0 by default', (): void => {
+      expect.assertions(1);
+
+      const result = operations.getConsumedOperationsCount();
+
+      expect(result).toStrictEqual(0);
+    });
+  });
+});

--- a/src/classes/operations.ts
+++ b/src/classes/operations.ts
@@ -1,33 +1,17 @@
-import {IIssuesProcessorOptions} from '../interfaces/issues-processor-options';
-
 export class Operations {
-  private readonly _options: IIssuesProcessorOptions;
-  private _operationsLeft;
-
-  constructor(options: Readonly<IIssuesProcessorOptions>) {
-    this._options = options;
-    this._operationsLeft = this._options.operationsPerRun;
-  }
+  protected _operationsConsumed = 0;
 
   consumeOperation(): Operations {
     return this.consumeOperations(1);
   }
 
   consumeOperations(quantity: Readonly<number>): Operations {
-    this._operationsLeft -= quantity;
+    this._operationsConsumed += quantity;
 
     return this;
   }
 
-  getUnconsumedOperationsCount(): number {
-    return this._options.operationsPerRun - this._operationsLeft;
-  }
-
-  hasOperationsLeft(): boolean {
-    return this._operationsLeft <= 0;
-  }
-
-  getOperationsLeftCount(): number {
-    return this._operationsLeft;
+  getConsumedOperationsCount(): number {
+    return this._operationsConsumed;
   }
 }

--- a/src/classes/stale-operations.spec.ts
+++ b/src/classes/stale-operations.spec.ts
@@ -1,0 +1,134 @@
+import {DefaultProcessorOptions} from '../../__tests__/constants/default-processor-options';
+import {IIssuesProcessorOptions} from '../interfaces/issues-processor-options';
+import {StaleOperations} from './stale-operations';
+
+interface IHasRemainingOperationsMatrix {
+  operationsPerRun: number;
+  consumeOperations: number;
+  hasRemainingOperations: number;
+}
+
+interface IGetRemainingOperationsCountMatrix {
+  operationsPerRun: number;
+  consumeOperations: number;
+  getRemainingOperationsCount: number;
+}
+
+describe('StaleOperations', (): void => {
+  let operations: StaleOperations;
+  let options: IIssuesProcessorOptions;
+
+  beforeEach((): void => {
+    options = {...DefaultProcessorOptions};
+  });
+
+  describe('consumeOperation()', (): void => {
+    beforeEach((): void => {
+      operations = new StaleOperations(options);
+    });
+
+    it('should increase the count of operation consume by 1', (): void => {
+      expect.assertions(1);
+      operations.consumeOperation();
+
+      const result = operations.getConsumedOperationsCount();
+
+      expect(result).toStrictEqual(1);
+    });
+  });
+
+  describe('consumeOperations()', (): void => {
+    beforeEach((): void => {
+      operations = new StaleOperations(options);
+    });
+
+    it('should increase the count of operation consume by the provided quantity', (): void => {
+      expect.assertions(1);
+      operations.consumeOperations(8);
+
+      const result = operations.getConsumedOperationsCount();
+
+      expect(result).toStrictEqual(8);
+    });
+  });
+
+  describe('getConsumedOperationsCount()', (): void => {
+    beforeEach((): void => {
+      operations = new StaleOperations(options);
+    });
+
+    it('should return 0 by default', (): void => {
+      expect.assertions(1);
+
+      const result = operations.getConsumedOperationsCount();
+
+      expect(result).toStrictEqual(0);
+    });
+  });
+
+  describe('hasRemainingOperations()', (): void => {
+    beforeEach((): void => {
+      operations = new StaleOperations(options);
+    });
+
+    describe.each`
+      operationsPerRun | consumeOperations | hasRemainingOperations
+      ${1}             | ${1}              | ${false}
+      ${2}             | ${1}              | ${true}
+    `(
+      'when the operations per run is $operationsPerRun and $consumeOperations operations were consumed',
+      ({
+        operationsPerRun,
+        consumeOperations,
+        hasRemainingOperations
+      }: IHasRemainingOperationsMatrix): void => {
+        beforeEach((): void => {
+          options.operationsPerRun = operationsPerRun;
+          operations = new StaleOperations(options);
+        });
+
+        it(`should return ${hasRemainingOperations}`, (): void => {
+          expect.assertions(1);
+          operations.consumeOperations(consumeOperations);
+
+          const result = operations.hasRemainingOperations();
+
+          expect(result).toStrictEqual(hasRemainingOperations);
+        });
+      }
+    );
+  });
+
+  describe('getRemainingOperationsCount()', (): void => {
+    beforeEach((): void => {
+      operations = new StaleOperations(options);
+    });
+
+    describe.each`
+      operationsPerRun | consumeOperations | getRemainingOperationsCount
+      ${1}             | ${1}              | ${0}
+      ${2}             | ${1}              | ${1}
+    `(
+      'when the operations per run is $operationsPerRun and $consumeOperations operations were consumed',
+      ({
+        operationsPerRun,
+        consumeOperations,
+        getRemainingOperationsCount
+      }: IGetRemainingOperationsCountMatrix): void => {
+        beforeEach((): void => {
+          options.operationsPerRun = operationsPerRun;
+          operations = new StaleOperations(options);
+        });
+
+        it(`should return ${getRemainingOperationsCount}`, (): void => {
+          expect.assertions(1);
+          operations.consumeOperations(consumeOperations);
+
+          const result = operations.getRemainingOperationsCount();
+
+          expect(result).toStrictEqual(getRemainingOperationsCount);
+        });
+      }
+    );
+  });
+});

--- a/src/classes/stale-operations.ts
+++ b/src/classes/stale-operations.ts
@@ -1,0 +1,19 @@
+import {IIssuesProcessorOptions} from '../interfaces/issues-processor-options';
+import {Operations} from './operations';
+
+export class StaleOperations extends Operations {
+  private readonly _options: IIssuesProcessorOptions;
+
+  constructor(options: Readonly<IIssuesProcessorOptions>) {
+    super();
+    this._options = options;
+  }
+
+  hasRemainingOperations(): boolean {
+    return this._operationsConsumed < this._options.operationsPerRun;
+  }
+
+  getRemainingOperationsCount(): number {
+    return this._options.operationsPerRun - this._operationsConsumed;
+  }
+}

--- a/src/classes/statistics.ts
+++ b/src/classes/statistics.ts
@@ -65,8 +65,8 @@ export class Statistics {
     return this._incrementUndoStaleIssuesCount(increment);
   }
 
-  setOperationsLeft(operationsLeft: Readonly<number>): Statistics {
-    this._operationsCount = operationsLeft;
+  setRemainingOperations(remainingOperations: Readonly<number>): Statistics {
+    this._operationsCount = remainingOperations;
 
     return this;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
-import {isValidDate} from './functions/dates/is-valid-date';
 import {IssuesProcessor} from './classes/issues-processor';
+import {isValidDate} from './functions/dates/is-valid-date';
 import {IIssuesProcessorOptions} from './interfaces/issues-processor-options';
 
 async function _run(): Promise<void> {
@@ -85,9 +85,9 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     'operations-per-run'
   ]) {
     if (isNaN(parseInt(core.getInput(numberInput)))) {
-      core.setFailed(
-        new Error(`Option "${numberInput}" did not parse to a valid integer`)
-      );
+      const errorMessage = `Option "${numberInput}" did not parse to a valid integer`;
+      core.setFailed(errorMessage);
+      throw new Error(errorMessage);
     }
   }
 
@@ -95,11 +95,9 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     // Ignore empty dates because it is considered as the right type for a default value (so a valid one)
     if (core.getInput(optionalDateInput) !== '') {
       if (!isValidDate(new Date(core.getInput(optionalDateInput)))) {
-        core.setFailed(
-          new Error(
-            `Option "${optionalDateInput}" did not parse to a valid date`
-          )
-        );
+        const errorMessage = `Option "${optionalDateInput}" did not parse to a valid date`;
+        core.setFailed(errorMessage);
+        throw new Error(errorMessage);
       }
     }
   }


### PR DESCRIPTION
…on (#386)

* docs(only-labels): enhance the docs and fix duplicate (#341)

* docs(only-labels): remove duplicated option and improve descriptions

a bad rebase happend

* docs(readme): use a multi-line array and remove the optional column

the option column was not helpful since each value is optional
the multi-line array will allow to have a better UI in small devices and basically in GitHub too due to the max-width

* style(readme): break line for the statistics

* docs(readme): add a better description for the ascending option

* docs(action): add missing punctuation

* build(deps-dev): bump @typescript-eslint/eslint-plugin (#342)

Bumps [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) from 4.15.2 to 4.16.1.
- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)
- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/CHANGELOG.md)
- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v4.16.1/packages/eslint-plugin)

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump @octokit/rest from 18.3.0 to 18.3.2 (#350)

Bumps [@octokit/rest](https://github.com/octokit/rest.js) from 18.3.0 to 18.3.2.
- [Release notes](https://github.com/octokit/rest.js/releases)
- [Commits](https://github.com/octokit/rest.js/compare/v18.3.0...v18.3.2)

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* test: add more coverage for the stale label behaviour (#352) (#15)

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* test: add more coverage for the stale label behaviour (#352) (#17)

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* test: add more coverage for the stale label behaviour (#352) (#18)

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* docs(operations-per-run): improve the doc for this option

* feat(logs): add a new log when an issue consumed at least one operation

the log will be visible as the last row of the processing of the given issue
closes #348

* chore(readme): improve the operations per run

Co-authored-by: HonkingGoose <34918129+HonkingGoose@users.noreply.github.com>

* chore(readme): improve the operations per run

Co-authored-by: HonkingGoose <34918129+HonkingGoose@users.noreply.github.com>

* chore(readme): improve the operations per run

Co-authored-by: HonkingGoose <34918129+HonkingGoose@users.noreply.github.com>

* chore(readme): improve the operations per run

Co-authored-by: HonkingGoose <34918129+HonkingGoose@users.noreply.github.com>

* chore(readme): improve the operations per run

Co-authored-by: HonkingGoose <34918129+HonkingGoose@users.noreply.github.com>

* chore(readme): improve the operations per run

Co-authored-by: HonkingGoose <34918129+HonkingGoose@users.noreply.github.com>

* Typo in how to perform check for specific labels (#357)

Not tests but feels like a typo.

Or if we keep the title it `exempt` feels more approriate:

          exempt-issue-labels: 'roadmap'
          exempt-pr-labels: 'roadmap'

* feat(any-of-labels): add 2 new options to customize for issues/PRs (#380)

* docs(only-labels): enhance the docs and fix duplicate (#341)

* docs(only-labels): remove duplicated option and improve descriptions

a bad rebase happend

* docs(readme): use a multi-line array and remove the optional column

the option column was not helpful since each value is optional
the multi-line array will allow to have a better UI in small devices and basically in GitHub too due to the max-width

* style(readme): break line for the statistics

* docs(readme): add a better description for the ascending option

* docs(action): add missing punctuation

* build(deps-dev): bump @typescript-eslint/eslint-plugin (#342)

Bumps [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) from 4.15.2 to 4.16.1.
- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)
- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/CHANGELOG.md)
- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v4.16.1/packages/eslint-plugin)

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump @octokit/rest from 18.3.0 to 18.3.2 (#350)

Bumps [@octokit/rest](https://github.com/octokit/rest.js) from 18.3.0 to 18.3.2.
- [Release notes](https://github.com/octokit/rest.js/releases)
- [Commits](https://github.com/octokit/rest.js/compare/v18.3.0...v18.3.2)

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* test: add more coverage for the stale label behaviour (#352) (#15)

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* test: add more coverage for the stale label behaviour (#352) (#17)

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* test: add more coverage for the stale label behaviour (#352) (#18)

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* feat(any-of-labels): add 2 new options to customize for issues/PRs

closes #371
change this option and only-labels to have tree-logs

* chore(index): update it

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* feat(logs): enhance the logs for assignees and milestones (#382)

* docs(only-labels): enhance the docs and fix duplicate (#341)

* docs(only-labels): remove duplicated option and improve descriptions

a bad rebase happend

* docs(readme): use a multi-line array and remove the optional column

the option column was not helpful since each value is optional
the multi-line array will allow to have a better UI in small devices and basically in GitHub too due to the max-width

* style(readme): break line for the statistics

* docs(readme): add a better description for the ascending option

* docs(action): add missing punctuation

* build(deps-dev): bump @typescript-eslint/eslint-plugin (#342)

Bumps [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) from 4.15.2 to 4.16.1.
- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)
- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/CHANGELOG.md)
- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v4.16.1/packages/eslint-plugin)

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump @octokit/rest from 18.3.0 to 18.3.2 (#350)

Bumps [@octokit/rest](https://github.com/octokit/rest.js) from 18.3.0 to 18.3.2.
- [Release notes](https://github.com/octokit/rest.js/releases)
- [Commits](https://github.com/octokit/rest.js/compare/v18.3.0...v18.3.2)

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* test: add more coverage for the stale label behaviour (#352) (#15)

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* test: add more coverage for the stale label behaviour (#352) (#17)

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* test: add more coverage for the stale label behaviour (#352) (#18)

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* feat(logs): enhance the logs for assignees and milestones

closes #381

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* style(typo): fix typo plural issue

* style(naming): rename two methods

* chore(error): remove a potential useless throw of error

* style(naming): rename one method

* refactor(issue): change the way to count the operations

* refactor(operations): create a method to reduce code duplication

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: HonkingGoose <34918129+HonkingGoose@users.noreply.github.com>
Co-authored-by: Romain Rigaux <romain.rigaux@gmail.com>